### PR TITLE
Make orthogonal_iteration() exit early upon convergence

### DIFF
--- a/apriltag_pose.c
+++ b/apriltag_pose.c
@@ -120,9 +120,16 @@ double orthogonal_iteration(matd_t** v, matd_t** p, matd_t** t, matd_t** R, int 
             error += matd_to_double(matd_op("M'M", err_vec, err_vec));
             matd_destroy(err_vec);
         }
-        prev_error = error;
 
         free(q);
+
+        // Return early if the iterations converged
+        if (fabs(error - prev_error) < 1e-2) {
+          prev_error = error;
+          break;
+        }
+
+        prev_error = error;
     }
 
     matd_destroy(I3);

--- a/apriltag_pose.c
+++ b/apriltag_pose.c
@@ -35,12 +35,13 @@ double matd_to_double(matd_t *a)
  * @param R In/Outparam. Should be set to initial guess at R. Will be modified to be the optimal translation.
  * @param n_points Number of points.
  * @param n_steps Number of iterations.
+ * @param min_improvement_per_iteration Min object-space error improvement; if less than this, solver will exit early
  *
  * @return Object-space error after iteration.
  *
  * Implementation of Orthogonal Iteration from Lu, 2000.
  */
-double orthogonal_iteration(matd_t** v, matd_t** p, matd_t** t, matd_t** R, int n_points, int n_steps) {
+double orthogonal_iteration(matd_t** v, matd_t** p, matd_t** t, matd_t** R, int n_points, int n_steps, double min_improvement_per_iteration) {
     matd_t* p_mean = matd_create(3, 1);
     for (int i = 0; i < n_points; i++) {
         matd_add_inplace(p_mean, p[i]);
@@ -125,7 +126,8 @@ double orthogonal_iteration(matd_t** v, matd_t** p, matd_t** t, matd_t** R, int 
         free(q);
 
         // Return early if the iterations converged
-        if (error < 1e-6) {
+        if (fabs(error - prev_error) < min_improvement_per_iteration) {
+          prev_error = error;
           break;
         }
     }
@@ -498,7 +500,8 @@ void estimate_tag_pose_orthogonal_iteration(
         apriltag_pose_t* solution1,
         double* err2,
         apriltag_pose_t* solution2,
-        int nIters) {
+        int nIters,
+        double min_improvement_per_iteration) {
     double scale = info->tagsize/2.0;
     matd_t* p[4] = {
         matd_create_data(3, 1, (double[]) {-scale, scale, 0}),
@@ -512,11 +515,11 @@ void estimate_tag_pose_orthogonal_iteration(
     }
 
     estimate_pose_for_tag_homography(info, solution1);
-    *err1 = orthogonal_iteration(v, p, &solution1->t, &solution1->R, 4, nIters);
+    *err1 = orthogonal_iteration(v, p, &solution1->t, &solution1->R, 4, nIters, min_improvement_per_iteration);
     solution2->R = fix_pose_ambiguities(v, p, solution1->t, solution1->R, 4);
     if (solution2->R) {
         solution2->t = matd_create(3, 1);
-        *err2 = orthogonal_iteration(v, p, &solution2->t, &solution2->R, 4, nIters);
+        *err2 = orthogonal_iteration(v, p, &solution2->t, &solution2->R, 4, nIters, min_improvement_per_iteration);
     } else {
         solution2->t = NULL;
         *err2 = HUGE_VAL;
@@ -534,7 +537,9 @@ void estimate_tag_pose_orthogonal_iteration(
 double estimate_tag_pose(apriltag_detection_info_t* info, apriltag_pose_t* pose) {
     double err1, err2;
     apriltag_pose_t pose1, pose2;
-    estimate_tag_pose_orthogonal_iteration(info, &err1, &pose1, &err2, &pose2, 50);
+    // 50 iterations is a good sensible default
+    // 1e-7 improvement per iteration is also pretty sane
+    estimate_tag_pose_orthogonal_iteration(info, &err1, &pose1, &err2, &pose2, 50, 1e-7);
     if (err1 <= err2) {
         pose->R = pose1.R;
         pose->t = pose1.t;

--- a/apriltag_pose.c
+++ b/apriltag_pose.c
@@ -120,16 +120,14 @@ double orthogonal_iteration(matd_t** v, matd_t** p, matd_t** t, matd_t** R, int 
             error += matd_to_double(matd_op("M'M", err_vec, err_vec));
             matd_destroy(err_vec);
         }
+        prev_error = error;
 
         free(q);
 
         // Return early if the iterations converged
-        if (fabs(error - prev_error) < 1e-2) {
-          prev_error = error;
+        if (error < 1e-6) {
           break;
         }
-
-        prev_error = error;
     }
 
     matd_destroy(I3);

--- a/apriltag_pose.h
+++ b/apriltag_pose.h
@@ -58,7 +58,8 @@ void estimate_tag_pose_orthogonal_iteration(
         apriltag_pose_t* pose1,
         double* err2,
         apriltag_pose_t* pose2,
-        int nIters);
+        int nIters, 
+        double min_improvement_per_iteration);
 
 /**
  * Estimate tag pose.

--- a/common/getopt.c
+++ b/common/getopt.c
@@ -1,0 +1,548 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include "zhash.h"
+#include "zarray.h"
+#include "getopt.h"
+#include "common/math_util.h"
+
+#define GOO_BOOL_TYPE 1
+#define GOO_STRING_TYPE 2
+
+typedef struct getopt_option getopt_option_t;
+
+struct getopt_option
+{
+	char *sname;
+	char *lname;
+	char *svalue;
+
+	char *help;
+	int type;
+
+	int spacer;
+
+    int was_specified;
+};
+
+struct getopt
+{
+    zhash_t  *lopts;
+    zhash_t  *sopts;
+    zarray_t   *extraargs;
+    zarray_t   *options;
+};
+
+getopt_t *getopt_create()
+{
+    getopt_t *gopt = (getopt_t*) calloc(1, sizeof(getopt_t));
+
+    gopt->lopts     = zhash_create(sizeof(char*), sizeof(getopt_option_t*), zhash_str_hash, zhash_str_equals);
+    gopt->sopts     = zhash_create(sizeof(char*), sizeof(getopt_option_t*), zhash_str_hash, zhash_str_equals);
+    gopt->options   = zarray_create(sizeof(getopt_option_t*));
+    gopt->extraargs = zarray_create(sizeof(char*));
+
+    return gopt;
+}
+
+void getopt_option_destroy(getopt_option_t *goo)
+{
+    free(goo->sname);
+    free(goo->lname);
+    free(goo->svalue);
+    free(goo->help);
+    memset(goo, 0, sizeof(getopt_option_t));
+    free(goo);
+}
+
+void getopt_destroy(getopt_t *gopt)
+{
+    // free the extra arguments and container
+    zarray_vmap(gopt->extraargs, free);
+    zarray_destroy(gopt->extraargs);
+
+    // deep free of the getopt_option structs. Also frees key/values, so
+    // after this loop, hash tables will no longer work
+    zarray_vmap(gopt->options, getopt_option_destroy);
+    zarray_destroy(gopt->options);
+
+    // free tables
+    zhash_destroy(gopt->lopts);
+    zhash_destroy(gopt->sopts);
+
+    memset(gopt, 0, sizeof(getopt_t));
+    free(gopt);
+}
+
+static void getopt_modify_string(char **str, char *newvalue)
+{
+    char *old = *str;
+    *str = newvalue;
+    if (old != NULL)
+        free(old);
+}
+
+static char *get_arg_assignment(char *arg)
+{
+    // not an arg starting with "--"?
+    if (!str_starts_with(arg, "--")) {
+        return NULL;
+    }
+
+    int eq_index = str_indexof(arg, "=");
+
+    // no assignment?
+    if (eq_index == -1) {
+        return NULL;
+    }
+
+    // no quotes allowed before '=' in "--key=value" option specification.
+    // quotes can be used in value string, or by extra arguments
+    for (int i = 0; i < eq_index; i++) {
+        if (arg[i] == '\'' || arg[i] == '"') {
+            return NULL;
+        }
+    }
+
+    return &arg[eq_index];
+}
+
+// returns 1 if no error
+int getopt_parse(getopt_t *gopt, int argc, char *argv[], int showErrors)
+{
+    int okay = 1;
+    zarray_t *toks = zarray_create(sizeof(char*));
+
+    // take the input stream and chop it up into tokens
+    for (int i = 1; i < argc; i++) {
+
+        char *arg = strdup(argv[i]);
+        char *eq  = get_arg_assignment(arg);
+
+        // no equal sign? Push the whole thing.
+        if (eq == NULL) {
+            zarray_add(toks, &arg);
+        } else {
+            // there was an equal sign. Push the part
+            // before and after the equal sign
+            char *val = strdup(&eq[1]);
+            eq[0] = 0;
+            zarray_add(toks, &arg);
+
+            // if the part after the equal sign is
+            // enclosed by quotation marks, strip them.
+            if (val[0]=='\"') {
+                size_t last = strlen(val) - 1;
+                if (val[last]=='\"')
+                    val[last] = 0;
+                char *valclean = strdup(&val[1]);
+                zarray_add(toks, &valclean);
+                free(val);
+            } else {
+                zarray_add(toks, &val);
+            }
+        }
+    }
+
+    // now loop over the elements and evaluate the arguments
+    unsigned int i = 0;
+
+    char *tok = NULL;
+
+    while (i < zarray_size(toks)) {
+
+        // rather than free statement throughout this while loop
+        if (tok != NULL)
+            free(tok);
+
+        zarray_get(toks, i, &tok);
+
+        if (!strncmp(tok,"--", 2)) {
+            char *optname = &tok[2];
+            getopt_option_t *goo = NULL;
+            zhash_get(gopt->lopts, &optname, &goo);
+            if (goo == NULL) {
+                okay = 0;
+                if (showErrors)
+                    printf("Unknown option --%s\n", optname);
+                i++;
+                continue;
+            }
+
+            goo->was_specified = 1;
+
+            if (goo->type == GOO_BOOL_TYPE) {
+                if ((i+1) < zarray_size(toks)) {
+                    char *val = NULL;
+                    zarray_get(toks, i+1, &val);
+
+                    if (!strcmp(val,"true")) {
+                        i+=2;
+                        getopt_modify_string(&goo->svalue, val);
+                        continue;
+                    }
+                    if (!strcmp(val,"false")) {
+                        i+=2;
+                        getopt_modify_string(&goo->svalue, val);
+                        continue;
+                    }
+                }
+                getopt_modify_string(&goo->svalue, strdup("true"));
+                i++;
+                continue;
+            }
+
+            if (goo->type == GOO_STRING_TYPE) {
+                // TODO: check whether next argument is an option, denoting missing argument
+                if ((i+1) < zarray_size(toks)) {
+                    char *val = NULL;
+                    zarray_get(toks, i+1, &val);
+                    i+=2;
+                    getopt_modify_string(&goo->svalue, val);
+                    continue;
+                }
+
+                okay = 0;
+                if (showErrors)
+                    printf("Option %s requires a string argument.\n",optname);
+            }
+        }
+
+        if (!strncmp(tok,"-",1) && strncmp(tok,"--",2)) {
+            size_t len = strlen(tok);
+            int pos;
+            for (pos = 1; pos < len; pos++) {
+                char sopt[2];
+                sopt[0] = tok[pos];
+                sopt[1] = 0;
+                char *sopt_ptr = (char*) &sopt;
+                getopt_option_t *goo = NULL;
+                zhash_get(gopt->sopts, &sopt_ptr, &goo);
+
+                if (goo==NULL) {
+                    // is the argument a numerical literal that happens to be negative?
+                    if (pos==1 && isdigit(tok[pos])) {
+                        zarray_add(gopt->extraargs, &tok);
+                        tok = NULL;
+                        break;
+                    } else {
+                        okay = 0;
+                        if (showErrors)
+                            printf("Unknown option -%c\n", tok[pos]);
+                        i++;
+                        continue;
+                    }
+                }
+
+                goo->was_specified = 1;
+
+                if (goo->type == GOO_BOOL_TYPE) {
+                    getopt_modify_string(&goo->svalue, strdup("true"));
+                    continue;
+                }
+
+                if (goo->type == GOO_STRING_TYPE) {
+                    if ((i+1) < zarray_size(toks)) {
+                        char *val = NULL;
+                        zarray_get(toks, i+1, &val);
+                        // TODO: allow negative numerical values for short-name options ?
+                        if (val[0]=='-')
+                        {
+                            okay = 0;
+                            if (showErrors)
+                                printf("Ran out of arguments for option block %s\n", tok);
+                        }
+                        i++;
+                        getopt_modify_string(&goo->svalue, val);
+                        continue;
+                    }
+
+                    okay = 0;
+                    if (showErrors)
+                        printf("Option -%c requires a string argument.\n", tok[pos]);
+                }
+            }
+            i++;
+            continue;
+        }
+
+        // it's not an option-- it's an argument.
+        zarray_add(gopt->extraargs, &tok);
+        tok = NULL;
+        i++;
+    }
+    if (tok != NULL)
+        free(tok);
+
+    zarray_destroy(toks);
+
+    return okay;
+}
+
+void getopt_add_spacer(getopt_t *gopt, const char *s)
+{
+    getopt_option_t *goo = (getopt_option_t*) calloc(1, sizeof(getopt_option_t));
+    goo->spacer = 1;
+    goo->help = strdup(s);
+    zarray_add(gopt->options, &goo);
+}
+
+void getopt_add_bool(getopt_t *gopt, char sopt, const char *lname, int def, const char *help)
+{
+    char sname[2];
+    sname[0] = sopt;
+    sname[1] = 0;
+    char *sname_ptr = (char*) &sname;
+
+    if (strlen(lname) < 1) { // must have long name
+        fprintf (stderr, "getopt_add_bool(): must supply option name\n");
+        exit (EXIT_FAILURE);
+    }
+
+    if (sopt == '-') { // short name cannot be '-' (no way to reference)
+        fprintf (stderr, "getopt_add_bool(): invalid option character: '%c'\n", sopt);
+        exit (EXIT_FAILURE);
+    }
+
+    if (zhash_contains(gopt->lopts, &lname)) {
+        fprintf (stderr, "getopt_add_bool(): duplicate option name: --%s\n", lname);
+        exit (EXIT_FAILURE);
+    }
+
+    if (sopt != '\0' && zhash_contains(gopt->sopts, &sname_ptr)) {
+        fprintf (stderr, "getopt_add_bool(): duplicate option: -%s ('%s')\n", sname, lname);
+        exit (EXIT_FAILURE);
+    }
+
+    getopt_option_t *goo = (getopt_option_t*) calloc(1, sizeof(getopt_option_t));
+    goo->sname=strdup(sname);
+    goo->lname=strdup(lname);
+    goo->svalue=strdup(def ? "true" : "false");
+    goo->type=GOO_BOOL_TYPE;
+    goo->help=strdup(help);
+
+    zhash_put(gopt->lopts, &goo->lname, &goo, NULL, NULL);
+    zhash_put(gopt->sopts, &goo->sname, &goo, NULL, NULL);
+    zarray_add(gopt->options, &goo);
+}
+
+void getopt_add_int(getopt_t *gopt, char sopt, const char *lname, const char *def, const char *help)
+{
+    getopt_add_string(gopt, sopt, lname, def, help);
+}
+
+void
+getopt_add_double (getopt_t *gopt, char sopt, const char *lname, const char *def, const char *help)
+{
+    getopt_add_string (gopt, sopt, lname, def, help);
+}
+
+void getopt_add_string(getopt_t *gopt, char sopt, const char *lname, const char *def, const char *help)
+{
+    char sname[2];
+    sname[0] = sopt;
+    sname[1] = 0;
+    char *sname_ptr = (char*) &sname;
+
+    if (strlen(lname) < 1) { // must have long name
+        fprintf (stderr, "getopt_add_string(): must supply option name\n");
+        exit (EXIT_FAILURE);
+    }
+
+    if (sopt == '-') { // short name cannot be '-' (no way to reference)
+        fprintf (stderr, "getopt_add_string(): invalid option character: '%c'\n", sopt);
+        exit (EXIT_FAILURE);
+    }
+
+    if (zhash_contains(gopt->lopts, &lname)) {
+        fprintf (stderr, "getopt_add_string(): duplicate option name: --%s\n", lname);
+        exit (EXIT_FAILURE);
+    }
+
+    if (sopt != '\0' && zhash_contains(gopt->sopts, &sname_ptr)) {
+        fprintf (stderr, "getopt_add_string(): duplicate option: -%s ('%s')\n", sname, lname);
+        exit (EXIT_FAILURE);
+    }
+
+    getopt_option_t *goo = (getopt_option_t*) calloc(1, sizeof(getopt_option_t));
+    goo->sname=strdup(sname);
+    goo->lname=strdup(lname);
+    goo->svalue=strdup(def);
+    goo->type=GOO_STRING_TYPE;
+    goo->help=strdup(help);
+
+    zhash_put(gopt->lopts, &goo->lname, &goo, NULL, NULL);
+    zhash_put(gopt->sopts, &goo->sname, &goo, NULL, NULL);
+    zarray_add(gopt->options, &goo);
+}
+
+const char *getopt_get_string(getopt_t *gopt, const char *lname)
+{
+    getopt_option_t *goo = NULL;
+    zhash_get(gopt->lopts, &lname, &goo);
+    // could return null, but this would be the only
+    // method that doesn't assert on a missing key
+    assert (goo != NULL);
+    return goo->svalue;
+}
+
+int getopt_get_int(getopt_t *getopt, const char *lname)
+{
+    const char *v = getopt_get_string(getopt, lname);
+    assert(v != NULL);
+
+    errno = 0;
+    char *endptr = (char *) v;
+    long val = strtol(v, &endptr, 10);
+
+    if (errno != 0) {
+        fprintf (stderr, "--%s argument: strtol failed: %s\n", lname, strerror(errno));
+        exit (EXIT_FAILURE);
+    }
+
+    if (endptr == v) {
+        fprintf (stderr, "--%s argument cannot be parsed as an int\n", lname);
+        exit (EXIT_FAILURE);
+    }
+
+    return (int) val;
+}
+
+int getopt_get_bool(getopt_t *getopt, const char *lname)
+{
+    const char *v = getopt_get_string(getopt, lname);
+    assert (v!=NULL);
+    int val = !strcmp(v, "true");
+    return val;
+}
+
+double getopt_get_double (getopt_t *getopt, const char *lname)
+{
+    const char *v = getopt_get_string (getopt, lname);
+    assert (v!=NULL);
+
+    errno = 0;
+    char *endptr = (char *) v;
+    double d = strtod (v, &endptr);
+
+    if (errno != 0) {
+        fprintf (stderr, "--%s argument: strtod failed: %s\n", lname, strerror(errno));
+        exit (EXIT_FAILURE);
+    }
+
+    if (endptr == v) {
+        fprintf (stderr, "--%s argument cannot be parsed as a double\n", lname);
+        exit (EXIT_FAILURE);
+    }
+
+    return d;
+}
+
+int getopt_was_specified(getopt_t *getopt, const char *lname)
+{
+    getopt_option_t *goo = NULL;
+    zhash_get(getopt->lopts, &lname, &goo);
+    if (goo == NULL)
+        return 0;
+
+    return goo->was_specified;
+}
+
+const zarray_t *getopt_get_extra_args(getopt_t *gopt)
+{
+    return gopt->extraargs;
+}
+
+void getopt_do_usage(getopt_t * gopt)
+{
+    char * usage = getopt_get_usage(gopt);
+    printf("%s", usage);
+    free(usage);
+}
+
+char * getopt_get_usage(getopt_t *gopt)
+{
+    string_buffer_t * sb = string_buffer_create();
+
+    int leftmargin=2;
+    int longwidth=12;
+    int valuewidth=10;
+
+    for (unsigned int i = 0; i < zarray_size(gopt->options); i++) {
+        getopt_option_t *goo = NULL;
+        zarray_get(gopt->options, i, &goo);
+
+        if (goo->spacer)
+            continue;
+
+        longwidth = max(longwidth, (int) strlen(goo->lname));
+
+        if (goo->type == GOO_STRING_TYPE)
+            valuewidth = max(valuewidth, (int) strlen(goo->svalue));
+    }
+
+    for (unsigned int i = 0; i < zarray_size(gopt->options); i++) {
+        getopt_option_t *goo = NULL;
+        zarray_get(gopt->options, i, &goo);
+
+        if (goo->spacer)
+        {
+            if (goo->help==NULL || strlen(goo->help)==0)
+                string_buffer_appendf(sb,"\n");
+            else
+                string_buffer_appendf(sb,"\n%*s%s\n\n", leftmargin, "", goo->help);
+            continue;
+        }
+
+        string_buffer_appendf(sb,"%*s", leftmargin, "");
+
+        if (goo->sname[0]==0)
+            string_buffer_appendf(sb,"     ");
+        else
+            string_buffer_appendf(sb,"-%c | ", goo->sname[0]);
+
+        string_buffer_appendf(sb,"--%*s ", -longwidth, goo->lname);
+
+        string_buffer_appendf(sb," [ %s ]", goo->svalue); // XXX: displays current value rather than default value
+
+        string_buffer_appendf(sb,"%*s", (int) (valuewidth-strlen(goo->svalue)), "");
+
+        string_buffer_appendf(sb," %s   ", goo->help);
+        string_buffer_appendf(sb,"\n");
+    }
+
+    char * usage = string_buffer_to_string(sb);
+    string_buffer_destroy(sb);
+    return usage;
+}

--- a/common/getopt.h
+++ b/common/getopt.h
@@ -1,0 +1,64 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+
+#pragma once
+
+#include "zarray.h"
+#include "string_util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct getopt getopt_t;
+
+getopt_t *getopt_create();
+void getopt_destroy(getopt_t *gopt);
+
+// Parse args. Returns 1 on success
+int getopt_parse(getopt_t *gopt, int argc, char *argv[], int showErrors);
+void getopt_do_usage(getopt_t *gopt);
+
+// Returns a string containing the usage. Must be freed by caller
+char * getopt_get_usage(getopt_t *gopt);
+
+void getopt_add_spacer(getopt_t *gopt, const char *s);
+void getopt_add_bool(getopt_t *gopt, char sopt, const char *lname, int def, const char *help);
+void getopt_add_int(getopt_t *gopt, char sopt, const char *lname, const char *def, const char *help);
+void getopt_add_string(getopt_t *gopt, char sopt, const char *lname, const char *def, const char *help);
+void getopt_add_double(getopt_t *gopt, char sopt, const char *lname, const char *def, const char *help);
+
+const char *getopt_get_string(getopt_t *gopt, const char *lname);
+int getopt_get_int(getopt_t *getopt, const char *lname);
+int getopt_get_bool(getopt_t *getopt, const char *lname);
+double getopt_get_double(getopt_t *getopt, const char *lname);
+int getopt_was_specified(getopt_t *gopt, const char *lname);
+const zarray_t *getopt_get_extra_args(getopt_t *gopt);
+
+#ifdef __cplusplus
+}
+#endif

--- a/common/pjpeg-idct.c
+++ b/common/pjpeg-idct.c
@@ -1,0 +1,388 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+
+#include <math.h>
+#include <stdint.h>
+
+#ifndef M_PI
+# define M_PI 3.141592653589793238462643383279502884196
+#endif
+
+// 8 bits of fixed-point output
+//
+// This implementation has a worst-case complexity of 22 multiplies
+// and 64 adds. This makes it significantly worse (about 2x) than the
+// best-known fast inverse cosine transform methods. HOWEVER, zero
+// coefficients can be skipped over, and since that's common (often
+// more than half the coefficients are zero).
+//
+// The output is scaled by a factor of 256 (due to our fixed-point
+// integer arithmetic)..
+static inline void idct_1D_u32(int32_t *in, int instride, int32_t *out, int outstride)
+{
+    for (int x = 0; x < 8; x++)
+        out[x*outstride] = 0;
+
+    int32_t c;
+
+    c = in[0*instride];
+    if (c) {
+        // 181  181  181  181  181  181  181  181
+        int32_t c181 = c * 181;
+        out[0*outstride] += c181;
+        out[1*outstride] += c181;
+        out[2*outstride] += c181;
+        out[3*outstride] += c181;
+        out[4*outstride] += c181;
+        out[5*outstride] += c181;
+        out[6*outstride] += c181;
+        out[7*outstride] += c181;
+    }
+
+    c = in[1*instride];
+    if (c) {
+        // 251  212  142   49  -49 -142 -212 -251
+        int32_t c251 = c * 251;
+        int32_t c212 = c * 212;
+        int32_t c142 = c * 142;
+        int32_t c49 = c * 49;
+        out[0*outstride] += c251;
+        out[1*outstride] += c212;
+        out[2*outstride] += c142;
+        out[3*outstride] += c49;
+        out[4*outstride] -= c49;
+        out[5*outstride] -= c142;
+        out[6*outstride] -= c212;
+        out[7*outstride] -= c251;
+    }
+
+    c = in[2*instride];
+    if (c) {
+        // 236   97  -97 -236 -236  -97   97  236
+        int32_t c236 = c*236;
+        int32_t c97 = c*97;
+        out[0*outstride] += c236;
+        out[1*outstride] += c97;
+        out[2*outstride] -= c97;
+        out[3*outstride] -= c236;
+        out[4*outstride] -= c236;
+        out[5*outstride] -= c97;
+        out[6*outstride] += c97;
+        out[7*outstride] += c236;
+    }
+
+    c = in[3*instride];
+    if (c) {
+        // 212  -49 -251 -142  142  251   49 -212
+        int32_t c212 = c*212;
+        int32_t c49 = c*49;
+        int32_t c251 = c*251;
+        int32_t c142 = c*142;
+        out[0*outstride] += c212;
+        out[1*outstride] -= c49;
+        out[2*outstride] -= c251;
+        out[3*outstride] -= c142;
+        out[4*outstride] += c142;
+        out[5*outstride] += c251;
+        out[6*outstride] += c49;
+        out[7*outstride] -= c212;
+    }
+
+    c = in[4*instride];
+    if (c) {
+        // 181 -181 -181  181  181 -181 -181  181
+        int32_t c181 = c*181;
+        out[0*outstride] += c181;
+        out[1*outstride] -= c181;
+        out[2*outstride] -= c181;
+        out[3*outstride] += c181;
+        out[4*outstride] += c181;
+        out[5*outstride] -= c181;
+        out[6*outstride] -= c181;
+        out[7*outstride] += c181;
+    }
+
+    c = in[5*instride];
+    if (c) {
+        // 142 -251   49  212 -212  -49  251 -142
+        int32_t c142 = c*142;
+        int32_t c251 = c*251;
+        int32_t c49 = c*49;
+        int32_t c212 = c*212;
+        out[0*outstride] += c142;
+        out[1*outstride] -= c251;
+        out[2*outstride] += c49;
+        out[3*outstride] += c212;
+        out[4*outstride] -= c212;
+        out[5*outstride] -= c49;
+        out[6*outstride] += c251;
+        out[7*outstride] -= c142;
+    }
+
+    c = in[6*instride];
+    if (c) {
+        //  97 -236  236  -97  -97  236 -236   97
+        int32_t c97 = c*97;
+        int32_t c236 = c*236;
+        out[0*outstride] += c97;
+        out[1*outstride] -= c236;
+        out[2*outstride] += c236;
+        out[3*outstride] -= c97;
+        out[4*outstride] -= c97;
+        out[5*outstride] += c236;
+        out[6*outstride] -= c236;
+        out[7*outstride] += c97;
+    }
+
+    c = in[7*instride];
+    if (c) {
+        //  49 -142  212 -251  251 -212  142  -49
+        int32_t c49 = c*49;
+        int32_t c142 = c*142;
+        int32_t c212 = c*212;
+        int32_t c251 = c*251;
+        out[0*outstride] += c49;
+        out[1*outstride] -= c142;
+        out[2*outstride] += c212;
+        out[3*outstride] -= c251;
+        out[4*outstride] += c251;
+        out[5*outstride] -= c212;
+        out[6*outstride] += c142;
+        out[7*outstride] -= c49;
+    }
+}
+
+void pjpeg_idct_2D_u32(int32_t in[64], uint8_t *out, uint32_t outstride)
+{
+    int32_t tmp[64];
+
+    // idct on rows
+    for (int y = 0; y < 8; y++)
+        idct_1D_u32(&in[8*y], 1, &tmp[8*y], 1);
+
+    int32_t tmp2[64];
+
+    // idct on columns
+    for (int x = 0; x < 8; x++)
+        idct_1D_u32(&tmp[x], 8, &tmp2[x], 8);
+
+    // scale, adjust bias, and clamp
+    for (int y = 0; y < 8; y++) {
+        for (int x = 0; x < 8; x++) {
+            int i = 8*y + x;
+
+            // Shift of 18: the divide by 4 as part of the idct, and a shift by 16
+            // to undo the fixed-point arithmetic. (We accumulated 8 bits of
+            // fractional precision during each of the row and column IDCTs)
+            //
+            // Originally:
+            //            int32_t v = (tmp2[i] >> 18) + 128;
+            //
+            // Move the add before the shift and we can do rounding at
+            // the same time.
+            const int32_t offset = (128 << 18) + (1 << 17);
+            int32_t v = (tmp2[i] + offset) >> 18;
+
+            if (v < 0)
+                v = 0;
+            if (v > 255)
+                v = 255;
+
+            out[y*outstride + x] = v;
+        }
+    }
+}
+
+///////////////////////////////////////////////////////
+// Below: a "as straight-forward as I can make" implementation.
+static inline void idct_1D_double(double *in, int instride, double *out, int outstride)
+{
+    for (int x = 0; x < 8; x++)
+        out[x*outstride] = 0;
+
+    // iterate over IDCT coefficients
+    double Cu = 1/sqrt(2);
+
+    for (int u = 0; u < 8; u++, Cu = 1) {
+
+        double coeff = in[u*instride];
+        if (coeff == 0)
+            continue;
+
+        for (int x = 0; x < 8; x++)
+            out[x*outstride] += Cu*cos((2*x+1)*u*M_PI/16) * coeff;
+    }
+}
+
+void pjpeg_idct_2D_double(int32_t in[64], uint8_t *out, uint32_t outstride)
+{
+    double din[64], dout[64];
+    for (int i = 0; i < 64; i++)
+        din[i] = in[i];
+
+    double tmp[64];
+
+    // idct on rows
+    for (int y = 0; y < 8; y++)
+        idct_1D_double(&din[8*y], 1, &tmp[8*y], 1);
+
+    // idct on columns
+    for (int x = 0; x < 8; x++)
+        idct_1D_double(&tmp[x], 8, &dout[x], 8);
+
+    // scale, adjust bias, and clamp
+    for (int y = 0; y < 8; y++) {
+        for (int x = 0; x < 8; x++) {
+            int i = 8*y + x;
+
+            dout[i] = (dout[i] / 4) + 128;
+            if (dout[i] < 0)
+                dout[i] = 0;
+            if (dout[i] > 255)
+                dout[i] = 255;
+
+            // XXX round by adding +.5?
+            out[y*outstride + x] = dout[i];
+        }
+    }
+}
+
+//////////////////////////////////////////////
+static inline unsigned char njClip(const int x) {
+    return (x < 0) ? 0 : ((x > 0xFF) ? 0xFF : (unsigned char) x);
+}
+
+#define W1 2841
+#define W2 2676
+#define W3 2408
+#define W5 1609
+#define W6 1108
+#define W7 565
+
+static inline void njRowIDCT(int* blk) {
+    int x0, x1, x2, x3, x4, x5, x6, x7, x8;
+    if (!((x1 = blk[4] << 11)
+        | (x2 = blk[6])
+        | (x3 = blk[2])
+        | (x4 = blk[1])
+        | (x5 = blk[7])
+        | (x6 = blk[5])
+        | (x7 = blk[3])))
+    {
+        blk[0] = blk[1] = blk[2] = blk[3] = blk[4] = blk[5] = blk[6] = blk[7] = blk[0] << 3;
+        return;
+    }
+    x0 = (blk[0] << 11) + 128;
+    x8 = W7 * (x4 + x5);
+    x4 = x8 + (W1 - W7) * x4;
+    x5 = x8 - (W1 + W7) * x5;
+    x8 = W3 * (x6 + x7);
+    x6 = x8 - (W3 - W5) * x6;
+    x7 = x8 - (W3 + W5) * x7;
+    x8 = x0 + x1;
+    x0 -= x1;
+    x1 = W6 * (x3 + x2);
+    x2 = x1 - (W2 + W6) * x2;
+    x3 = x1 + (W2 - W6) * x3;
+    x1 = x4 + x6;
+    x4 -= x6;
+    x6 = x5 + x7;
+    x5 -= x7;
+    x7 = x8 + x3;
+    x8 -= x3;
+    x3 = x0 + x2;
+    x0 -= x2;
+    x2 = (181 * (x4 + x5) + 128) >> 8;
+    x4 = (181 * (x4 - x5) + 128) >> 8;
+    blk[0] = (x7 + x1) >> 8;
+    blk[1] = (x3 + x2) >> 8;
+    blk[2] = (x0 + x4) >> 8;
+    blk[3] = (x8 + x6) >> 8;
+    blk[4] = (x8 - x6) >> 8;
+    blk[5] = (x0 - x4) >> 8;
+    blk[6] = (x3 - x2) >> 8;
+    blk[7] = (x7 - x1) >> 8;
+}
+
+static inline void njColIDCT(const int* blk, unsigned char *out, int stride) {
+    int x0, x1, x2, x3, x4, x5, x6, x7, x8;
+    if (!((x1 = blk[8*4] << 8)
+        | (x2 = blk[8*6])
+        | (x3 = blk[8*2])
+        | (x4 = blk[8*1])
+        | (x5 = blk[8*7])
+        | (x6 = blk[8*5])
+        | (x7 = blk[8*3])))
+    {
+        x1 = njClip(((blk[0] + 32) >> 6) + 128);
+        for (x0 = 8;  x0;  --x0) {
+            *out = (unsigned char) x1;
+            out += stride;
+        }
+        return;
+    }
+    x0 = (blk[0] << 8) + 8192;
+    x8 = W7 * (x4 + x5) + 4;
+    x4 = (x8 + (W1 - W7) * x4) >> 3;
+    x5 = (x8 - (W1 + W7) * x5) >> 3;
+    x8 = W3 * (x6 + x7) + 4;
+    x6 = (x8 - (W3 - W5) * x6) >> 3;
+    x7 = (x8 - (W3 + W5) * x7) >> 3;
+    x8 = x0 + x1;
+    x0 -= x1;
+    x1 = W6 * (x3 + x2) + 4;
+    x2 = (x1 - (W2 + W6) * x2) >> 3;
+    x3 = (x1 + (W2 - W6) * x3) >> 3;
+    x1 = x4 + x6;
+    x4 -= x6;
+    x6 = x5 + x7;
+    x5 -= x7;
+    x7 = x8 + x3;
+    x8 -= x3;
+    x3 = x0 + x2;
+    x0 -= x2;
+    x2 = (181 * (x4 + x5) + 128) >> 8;
+    x4 = (181 * (x4 - x5) + 128) >> 8;
+    *out = njClip(((x7 + x1) >> 14) + 128);  out += stride;
+    *out = njClip(((x3 + x2) >> 14) + 128);  out += stride;
+    *out = njClip(((x0 + x4) >> 14) + 128);  out += stride;
+    *out = njClip(((x8 + x6) >> 14) + 128);  out += stride;
+    *out = njClip(((x8 - x6) >> 14) + 128);  out += stride;
+    *out = njClip(((x0 - x4) >> 14) + 128);  out += stride;
+    *out = njClip(((x3 - x2) >> 14) + 128);  out += stride;
+    *out = njClip(((x7 - x1) >> 14) + 128);
+}
+
+void pjpeg_idct_2D_nanojpeg(int32_t in[64], uint8_t *out, uint32_t outstride)
+{
+    int coef;
+
+    for (coef = 0;  coef < 64;  coef += 8)
+        njRowIDCT(&in[coef]);
+    for (coef = 0;  coef < 8;  ++coef)
+        njColIDCT(&in[coef], &out[coef], outstride);
+}

--- a/common/pjpeg.c
+++ b/common/pjpeg.c
@@ -1,0 +1,894 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "pjpeg.h"
+
+#include "image_u8.h"
+#include "image_u8x3.h"
+#include "debug_print.h"
+
+// https://www.w3.org/Graphics/JPEG/itu-t81.pdf
+
+void pjpeg_idct_2D_double(int32_t in[64], uint8_t *out, uint32_t outstride);
+void pjpeg_idct_2D_u32(int32_t in[64], uint8_t *out, uint32_t outstride);
+void pjpeg_idct_2D_nanojpeg(int32_t in[64], uint8_t *out, uint32_t outstride);
+
+struct pjpeg_huffman_code
+{
+    uint8_t nbits;  // how many bits should we actually consume?
+    uint8_t code;   // what is the symbol that was encoded? (not actually a DCT coefficient; see encoding)
+};
+
+struct pjpeg_decode_state
+{
+    int error;
+
+    uint32_t width, height;
+    uint8_t *in;
+    uint32_t inlen;
+
+    uint32_t flags;
+
+    // to decode, we load the next 16 bits of input (generally more
+    // than we need). We then look up in our code book how many bits
+    // we have actually consumed. For example, if there was a code
+    // whose bit sequence was "0", the first 32768 entries would all
+    // be copies of {.bits=1, .value=XX}; no matter what the following
+    // 15 bits are, we would get the correct decode.
+    //
+    // Can be up to 8 tables; computed as (ACDC * 2 + htidx)
+    struct pjpeg_huffman_code huff_codes[4][65536];
+    int huff_codes_present[4];
+
+    uint8_t  qtab[4][64];
+
+    int ncomponents;
+    pjpeg_component_t *components;
+
+    int reset_interval;
+    int reset_count;
+    int reset_next; // What reset marker do we expect next? (add 0xd0)
+
+    int debug;
+};
+
+// from K.3.3.1 (page 158)
+static uint8_t mjpeg_dht[] = { // header
+    0xFF,0xC4,0x01,0xA2,
+
+    /////////////////////////////////////////////////////////////
+    // luminance dc coefficients.
+    // DC table 0
+    0x00,
+    // code lengths
+    0x00,0x01,0x05,0x01,0x01,0x01,0x01,0x01,0x01,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+    // values
+    0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,
+
+    /////////////////////////////////////////////////////////////
+    // chrominance DC coefficents
+    // DC table 1
+    0x01,
+    // code lengths
+    0x00,0x03,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x00,0x00,0x00,0x00,0x00,
+    // values
+    0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,
+
+    /////////////////////////////////////////////////////////////
+    // luminance AC coefficients
+    // AC table 0
+    0x10,
+    // code lengths
+    0x00,0x02,0x01,0x03,0x03,0x02,0x04,0x03,0x05,0x05,0x04,0x04,0x00,0x00,0x01,0x7D,
+    // codes
+    0x01,0x02,0x03,0x00,0x04,0x11,0x05,0x12,0x21,0x31,0x41,0x06,0x13,0x51,0x61,
+    0x07,0x22,0x71,0x14,0x32,0x81,0x91,0xA1,0x08,0x23,0x42,0xB1,0xC1,0x15,0x52,0xD1,0xF0,0x24,
+    0x33,0x62,0x72,0x82,0x09,0x0A,0x16,0x17,0x18,0x19,0x1A,0x25,0x26,0x27,0x28,0x29,0x2A,0x34,
+    0x35,0x36,0x37,0x38,0x39,0x3A,0x43,0x44,0x45,0x46,0x47,0x48,0x49,0x4A,0x53,0x54,0x55,0x56,
+    0x57,0x58,0x59,0x5A,0x63,0x64,0x65,0x66,0x67,0x68,0x69,0x6A,0x73,0x74,0x75,0x76,0x77,0x78,
+    0x79,0x7A,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8A,0x92,0x93,0x94,0x95,0x96,0x97,0x98,0x99,
+    0x9A,0xA2,0xA3,0xA4,0xA5,0xA6,0xA7,0xA8,0xA9,0xAA,0xB2,0xB3,0xB4,0xB5,0xB6,0xB7,0xB8,0xB9,
+    0xBA,0xC2,0xC3,0xC4,0xC5,0xC6,0xC7,0xC8,0xC9,0xCA,0xD2,0xD3,0xD4,0xD5,0xD6,0xD7,0xD8,0xD9,
+    0xDA,0xE1,0xE2,0xE3,0xE4,0xE5,0xE6,0xE7,0xE8,0xE9,0xEA,0xF1,0xF2,0xF3,0xF4,0xF5,0xF6,0xF7,
+    0xF8,0xF9,0xFA,
+
+    /////////////////////////////////////////////////////////////
+    // chrominance DC coefficients
+    // DC table 1
+    0x11,
+    // code lengths
+    0x00,0x02,0x01,0x02,0x04,0x04,0x03,0x04,0x07,0x05,0x04,0x04,0x00,0x01,0x02,0x77,
+    // values
+    0x00,0x01,0x02,0x03,0x11,0x04,0x05,0x21,0x31,0x06,0x12,0x41,0x51,0x07,0x61,0x71,
+    0x13,0x22,0x32,0x81,0x08,0x14,0x42,0x91,0xA1,0xB1,0xC1,0x09,0x23,0x33,0x52,0xF0,0x15,0x62,
+    0x72,0xD1,0x0A,0x16,0x24,0x34,0xE1,0x25,0xF1,0x17,0x18,0x19,0x1A,0x26,0x27,0x28,0x29,0x2A,
+    0x35,0x36,0x37,0x38,0x39,0x3A,0x43,0x44,0x45,0x46,0x47,0x48,0x49,0x4A,0x53,0x54,0x55,0x56,
+    0x57,0x58,0x59,0x5A,0x63,0x64,0x65,0x66,0x67,0x68,0x69,0x6A,0x73,0x74,0x75,0x76,0x77,0x78,
+    0x79,0x7A,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8A,0x92,0x93,0x94,0x95,0x96,0x97,0x98,
+    0x99,0x9A,0xA2,0xA3,0xA4,0xA5,0xA6,0xA7,0xA8,0xA9,0xAA,0xB2,0xB3,0xB4,0xB5,0xB6,0xB7,0xB8,
+    0xB9,0xBA,0xC2,0xC3,0xC4,0xC5,0xC6,0xC7,0xC8,0xC9,0xCA,0xD2,0xD3,0xD4,0xD5,0xD6,0xD7,0xD8,
+    0xD9,0xDA,0xE2,0xE3,0xE4,0xE5,0xE6,0xE7,0xE8,0xE9,0xEA,0xF2,0xF3,0xF4,0xF5,0xF6,0xF7,0xF8,
+    0xF9,0xFA
+};
+
+static inline uint8_t max_u8(uint8_t a, uint8_t b)
+{
+    return a > b ? a : b;
+}
+
+// order of coefficients in each DC block
+static const char ZZ[64] = { 0,   1,  8, 16,  9,  2,  3, 10,
+                             17, 24, 32, 25, 18, 11,  4,  5,
+                             12, 19, 26, 33, 40, 48, 41, 34,
+                             27, 20, 13,  6,  7, 14, 21, 28,
+                             35, 42, 49, 56, 57, 50, 43, 36,
+                             29, 22, 15, 23, 30, 37, 44, 51,
+                             58, 59, 52, 45, 38, 31, 39, 46,
+                             53, 60, 61, 54, 47, 55, 62, 63 };
+
+
+
+struct bit_decoder
+{
+    uint8_t *in;
+    uint32_t inpos;
+    uint32_t inlen;
+
+    uint32_t bits; // the low order bits contain the next nbits_avail bits.
+
+    int nbits_avail; // how many bits in 'bits' (left aligned) are valid?
+
+    int error;
+};
+
+// ensure that at least 'nbits' of data is available in the bit decoder.
+static inline void bd_ensure(struct bit_decoder *bd, int nbits)
+{
+    while (bd->nbits_avail < nbits) {
+
+        if (bd->inpos >= bd->inlen) {
+            printf("hallucinating 1s!\n");
+            // we hit end of stream hallucinate an infinite stream of 1s
+            bd->bits = (bd->bits << 8) | 0xff;
+            bd->nbits_avail += 8;
+            continue;
+        }
+
+        uint8_t nextbyte = bd->in[bd->inpos];
+        bd->inpos++;
+
+        if (nextbyte == 0xff && bd->inpos < bd->inlen && bd->in[bd->inpos] == 0x00) {
+            // a stuffed byte
+            nextbyte = 0xff;
+            bd->inpos++;
+        }
+
+        // it's an ordinary byte
+        bd->bits = (bd->bits << 8) | nextbyte;
+        bd->nbits_avail += 8;
+    }
+}
+
+static inline uint32_t bd_peek_bits(struct bit_decoder *bd, int nbits)
+{
+    bd_ensure(bd, nbits);
+
+    return (bd->bits >> (bd->nbits_avail - nbits)) & ((1 << nbits) - 1);
+}
+
+static inline uint32_t bd_consume_bits(struct bit_decoder *bd, int nbits)
+{
+    assert(nbits < 32);
+
+    bd_ensure(bd, nbits);
+
+    uint32_t v = (bd->bits >> (bd->nbits_avail - nbits)) & ((1 << nbits) - 1);
+
+    bd->nbits_avail -= nbits;
+
+    return v;
+}
+
+// discard without regard for byte stuffing!
+static inline void bd_discard_bytes(struct bit_decoder *bd, int nbytes)
+{
+    assert(bd->nbits_avail == 0);
+    bd->inpos += nbytes;
+}
+
+static inline int bd_has_more(struct bit_decoder *bd)
+{
+    return bd->nbits_avail > 0 || bd->inpos < bd->inlen;
+}
+
+// throw away up to 7 bits of data so that the next data returned
+// began on a byte boundary.
+static inline void bd_discard_to_byte_boundary(struct bit_decoder *bd)
+{
+    bd->nbits_avail -= (bd->nbits_avail & 7);
+}
+
+static inline uint32_t bd_get_offset(struct bit_decoder *bd)
+{
+    return bd->inpos - bd->nbits_avail / 8;
+}
+
+static int pjpeg_decode_buffer(struct pjpeg_decode_state *pjd)
+{
+    // XXX TODO Include sanity check that this is actually a JPG
+
+    struct bit_decoder bd;
+    memset(&bd, 0, sizeof(struct bit_decoder));
+    bd.in = pjd->in;
+    bd.inpos = 0;
+    bd.inlen = pjd->inlen;
+
+    int marker_sync_skipped = 0;
+    int marker_sync_skipped_from_offset = 0;
+
+    while (bd_has_more(&bd)) {
+
+        uint32_t marker_offset = bd_get_offset(&bd);
+
+        // Look for the 0xff that signifies the beginning of a marker
+        bd_discard_to_byte_boundary(&bd);
+
+        while (bd_consume_bits(&bd, 8) != 0xff) {
+            if (marker_sync_skipped == 0)
+                marker_sync_skipped_from_offset = marker_offset;
+            marker_sync_skipped++;
+            continue;
+        }
+
+        if (marker_sync_skipped) {
+            printf("%08x: skipped %04x bytes\n", marker_sync_skipped_from_offset, marker_sync_skipped);
+            marker_sync_skipped = 0;
+        }
+
+        uint8_t marker = bd_consume_bits(&bd, 8);
+
+//        printf("marker %08x : %02x\n", marker_offset, marker);
+
+        switch (marker) {
+
+            case 0xd8:  // start of image. Great, continue.
+                continue;
+
+                // below are the markers that A) we don't care about
+                // that B) encode length as two bytes.
+                //
+                // Note: Other unknown fields should not be added since
+                // we should be able to skip over them by looking for
+                // the next marker byte.
+            case 0xe0: // JFIF header.
+            case 0xe1: // EXIF header (Yuck: Payload may contain 0xff 0xff!)
+            case 0xe2: // ICC Profile. (Yuck: payload may contain 0xff 0xff!)
+            case 0xe6: // some other common header
+            case 0xfe: // Comment
+            {
+                uint16_t length = bd_consume_bits(&bd, 16);
+                bd_discard_bytes(&bd, length - 2);
+                continue;
+            }
+
+            case 0xdb: { // DQT Define Quantization Table
+                uint16_t length = bd_consume_bits(&bd, 16);
+
+                if (((length-2) % 65) != 0)
+                    return PJPEG_ERR_DQT;
+
+                // can contain multiple DQTs
+                for (int offset = 0; offset < length - 2; offset += 65) {
+
+                    // pq: quant table element precision. 0=8bit, 1=16bit.
+                    // tq: quant table destination id.
+                    uint8_t  pqtq = bd_consume_bits(&bd, 8);
+
+                    if ((pqtq & 0xf0) != 0 || (pqtq & 0x0f) >= 4)
+                        return PJPEG_ERR_DQT;
+
+                    uint8_t id = pqtq & 3;
+
+                    for (int i = 0; i < 64; i++)
+                        pjd->qtab[id][i] = bd_consume_bits(&bd, 8);
+                }
+
+                break;
+            }
+
+            case 0xc0: { // SOF, non-differential, huffman, baseline
+                uint16_t length = bd_consume_bits(&bd, 16);
+                (void) length;
+
+                uint8_t p = bd_consume_bits(&bd, 8); // precision
+                if (p != 8)
+                    return PJPEG_ERR_SOF;
+
+                pjd->height = bd_consume_bits(&bd, 16);
+                pjd->width = bd_consume_bits(&bd, 16);
+
+//                printf("%d x %d\n", pjd->height, pjd->width);
+
+                int nf = bd_consume_bits(&bd, 8); // # image components
+
+                if (nf < 1 || nf > 3)
+                    return PJPEG_ERR_SOF;
+
+                pjd->ncomponents = nf;
+                pjd->components = calloc(nf, sizeof(struct pjpeg_component));
+
+                for (int i = 0; i < nf; i++) {
+                    // comp. identifier
+                    pjd->components[i].id = bd_consume_bits(&bd, 8);
+
+                    // horiz/vert sampling
+                    pjd->components[i].hv = bd_consume_bits(&bd, 8);
+                    pjd->components[i].scaley = pjd->components[i].hv & 0x0f;
+                    pjd->components[i].scalex = pjd->components[i].hv >> 4;
+
+                    // which quant table?
+                    pjd->components[i].tq = bd_consume_bits(&bd, 8);
+                }
+                break;
+            }
+
+            case 0xc1: // SOF, non-differential, huffman,    extended DCT
+            case 0xc2: // SOF, non-differential, huffman,    progressive DCT
+            case 0xc3: // SOF, non-differential, huffman,    lossless
+            case 0xc5: // SOF, differential,     huffman,    baseline DCT
+            case 0xc6: // SOF, differential,     huffman,    progressive
+            case 0xc7: // SOF, differential,     huffman,    lossless
+            case 0xc8: // reserved
+            case 0xc9: // SOF, non-differential, arithmetic, extended
+            case 0xca: // SOF, non-differential, arithmetic, progressive
+            case 0xcb: // SOF, non-differential, arithmetic, lossless
+            case 0xcd: // SOF, differential,     arithmetic, sequential
+            case 0xce: // SOF, differential,     arithmetic, progressive
+            case 0xcf: // SOF, differential,     arithmetic, lossless
+            {
+                printf("pjepg.c: unsupported JPEG type %02x\n", marker);
+                return PJEPG_ERR_UNSUPPORTED;
+            }
+
+            case 0xc4: { // DHT Define Huffman Tables
+                // [ED: the encoding of these tables is really quite
+                // clever!]
+                uint16_t length = bd_consume_bits(&bd, 16);
+                length = length - 2;
+
+                while (length > 0) {
+                    uint8_t TcTh = bd_consume_bits(&bd, 8);
+                    length--;
+                    uint8_t Tc = (TcTh >> 4);
+                    int Th = TcTh & 0x0f; // which index are we using?
+
+                    if (Tc >= 2 || Th >= 2)
+                        // Tc must be either AC=1 or DC=0.
+                        // Th must be less than 2
+                        return PJPEG_ERR_DHT;
+
+                    int htidx = Tc*2 + Th;
+
+                    uint8_t L[17]; // how many symbols of each bit length?
+                    L[0] = 0;      // no 0 bit codes :)
+                    for (int nbits = 1; nbits <= 16; nbits++) {
+                        L[nbits] = bd_consume_bits(&bd, 8);
+                        length -= L[nbits];
+                    }
+                    length -= 16;
+
+                    uint32_t code_pos = 0;
+
+                    for (int nbits = 1; nbits <= 16; nbits++) {
+                        int nvalues = L[nbits];
+
+                        // how many entries will we fill?
+                        // (a 1 bit code will fill 32768, a 2 bit code 16384, ...)
+                        uint32_t ncodes = (1 << (16 - nbits));
+
+                        // consume the values...
+                        for (int vi = 0; vi < nvalues; vi++) {
+                            uint8_t code = bd_consume_bits(&bd, 8);
+
+                            if (code_pos + ncodes > 0xffff)
+                                return PJPEG_ERR_DHT;
+
+                            for (int ci = 0; ci < ncodes; ci++) {
+                                pjd->huff_codes[htidx][code_pos].nbits = nbits;
+                                pjd->huff_codes[htidx][code_pos].code = code;
+                                code_pos++;
+                            }
+                        }
+                    }
+                    pjd->huff_codes_present[htidx] = 1;
+                }
+                break;
+            }
+
+                // a sequentially-encoded JPG has one SOS segment. A
+                // progressive JPG will have multiple SOS segments.
+            case 0xda: { // Start Of Scan (SOS)
+
+                // Note that this marker frame (and its encoded
+                // length) does NOT include the bitstream that
+                // follows.
+
+                uint16_t length = bd_consume_bits(&bd, 16);
+                (void) length;
+
+                // number of components in this scan
+                uint8_t ns = bd_consume_bits(&bd, 8);
+
+                // for each component, what is the index into our pjd->components[] array?
+                uint8_t *comp_idx = calloc(ns, sizeof(uint8_t));
+
+                for (int i = 0; i < ns; i++) {
+                    // component name
+                    uint8_t cs = bd_consume_bits(&bd, 8);
+
+                    int found = 0;
+                    for (int j = 0; j < pjd->ncomponents; j++) {
+
+                        if (cs == pjd->components[j].id) {
+                            // which huff tables will we use for
+                            // DC (high 4 bits) and AC (low 4 bits)
+                            pjd->components[j].tda = bd_consume_bits(&bd, 8);
+                            comp_idx[i] = j;
+                            found = 1;
+                            break;
+                        }
+                    }
+
+                    if (!found)
+                        return PJPEG_ERR_SOS;
+                }
+
+                // start of spectral selection. baseline == 0
+                uint8_t ss = bd_consume_bits(&bd, 8);
+
+                // end of spectral selection. baseline == 0x3f
+                uint8_t se = bd_consume_bits(&bd, 8);
+
+                // successive approximation bits. baseline == 0
+                uint8_t Ahl = bd_consume_bits(&bd, 8);
+
+                if (ss != 0 || se != 0x3f || Ahl != 0x00)
+                    return PJPEG_ERR_SOS;
+
+                // compute the dimensions of each MCU in pixels
+                int maxmcux = 0, maxmcuy = 0;
+                for (int i = 0; i < ns; i++) {
+                    struct pjpeg_component *comp = &pjd->components[comp_idx[i]];
+
+                    maxmcux = max_u8(maxmcux, comp->scalex * 8);
+                    maxmcuy = max_u8(maxmcuy, comp->scaley * 8);
+                }
+
+                // how many MCU blocks are required to encode the whole image?
+                int mcus_x = (pjd->width + maxmcux - 1) / maxmcux;
+                int mcus_y = (pjd->height + maxmcuy - 1) / maxmcuy;
+
+                if (0)
+                    printf("Image has %d x %d MCU blocks, each %d x %d pixels\n",
+                           mcus_x, mcus_y, maxmcux, maxmcuy);
+
+                // allocate output storage
+                for (int i = 0; i < ns; i++) {
+                    struct pjpeg_component *comp = &pjd->components[comp_idx[i]];
+                    comp->width = mcus_x * comp->scalex * 8;
+                    comp->height = mcus_y * comp->scaley * 8;
+                    comp->stride = comp->width;
+
+                    int alignment = 32;
+                    if ((comp->stride % alignment) != 0)
+                        comp->stride += alignment - (comp->stride % alignment);
+
+                    comp->data = calloc(comp->height * comp->stride, 1);
+                }
+
+
+                // each component has its own DC prediction
+                int32_t *dcpred = calloc(ns, sizeof(int32_t));
+
+                pjd->reset_count = 0;
+
+                for (int mcu_y = 0; mcu_y < mcus_y; mcu_y++) {
+                    for (int mcu_x = 0; mcu_x < mcus_x; mcu_x++) {
+
+                        // the next two bytes in the input stream
+                        // should be 0xff 0xdN, where N is the next
+                        // reset counter.
+                        //
+                        // Our bit decoder may have already shifted
+                        // these into the buffer.  Consequently, we
+                        // want to use our bit decoding functions to
+                        // check for the marker. But we must first
+                        // discard any fractional bits left.
+                        if (pjd->reset_interval > 0 && pjd->reset_count == pjd->reset_interval) {
+
+                            // RST markers are byte-aligned, so force
+                            // the bit-decoder to the next byte
+                            // boundary.
+                            bd_discard_to_byte_boundary(&bd);
+
+                            while (1) {
+                                int32_t value = bd_consume_bits(&bd, 8);
+                                if (bd.inpos > bd.inlen)
+                                    return PJPEG_ERR_EOF;
+                                if (value == 0xff)
+                                    break;
+                                printf("RST SYNC\n");
+                            }
+
+                            int32_t marker_32 = bd_consume_bits(&bd, 8);
+
+//                            printf("%04x: RESET? %02x\n", *bd.inpos,  marker_32);
+                            if (marker_32 != (0xd0 + pjd->reset_next))
+                                return PJPEG_ERR_RESET;
+
+                            pjd->reset_count = 0;
+                            pjd->reset_next = (pjd->reset_next + 1) & 0x7;
+
+                            memset(dcpred, 0, sizeof(*dcpred));
+                        }
+
+                        for (int nsidx = 0; nsidx < ns; nsidx++) {
+
+                            struct pjpeg_component *comp = &pjd->components[comp_idx[nsidx]];
+
+                            int32_t block[64];
+
+                            int qtabidx = comp->tq; // which quant table?
+
+                            for (int sby = 0; sby < comp->scaley; sby++) {
+                                for (int sbx = 0; sbx < comp->scalex; sbx++) {
+                                    // decode block for component nsidx
+                                    memset(block, 0, sizeof(block));
+
+                                    int dc_huff_table_idx = comp->tda >> 4;
+                                    int ac_huff_table_idx = 2 + (comp->tda & 0x0f);
+
+                                    if (!pjd->huff_codes_present[dc_huff_table_idx] ||
+                                        !pjd->huff_codes_present[ac_huff_table_idx])
+                                        return PJPEG_ERR_MISSING_DHT; // probably an MJPEG.
+
+
+                                    if (1) {
+                                        // do DC coefficient
+                                        uint32_t next16 = bd_peek_bits(&bd, 16);
+                                        struct pjpeg_huffman_code *huff_code = &pjd->huff_codes[dc_huff_table_idx][next16];
+                                        bd_consume_bits(&bd, huff_code->nbits);
+
+                                        int ssss = huff_code->code & 0x0f; // ssss == number of additional bits to read
+                                        int32_t value = bd_consume_bits(&bd, ssss);
+
+                                        // if high bit is clear, it's negative
+                                        if ((value & (1 << (ssss-1))) == 0)
+                                            value += ((-1) << ssss) + 1;
+
+                                        dcpred[nsidx] += value;
+                                        block[0] = dcpred[nsidx] * pjd->qtab[qtabidx][0];
+                                    }
+
+                                    if (1) {
+                                        // do AC coefficients
+                                        for (int coeff = 1; coeff < 64; coeff++) {
+
+                                            uint32_t next16 = bd_peek_bits(&bd, 16);
+
+                                            struct pjpeg_huffman_code *huff_code = &pjd->huff_codes[ac_huff_table_idx][next16];
+                                            bd_consume_bits(&bd, huff_code->nbits);
+
+                                            if (huff_code->code == 0) {
+                                                break; // EOB
+                                            }
+
+                                            int rrrr = huff_code->code >> 4; // run length of zeros
+                                            int ssss = huff_code->code & 0x0f;
+
+                                            int32_t value = bd_consume_bits(&bd, ssss);
+
+                                            // if high bit is clear, it's negative
+                                            if ((value & (1 << (ssss-1))) == 0)
+                                                value += ((-1) << ssss) + 1;
+
+                                            coeff += rrrr;
+
+                                            block[(int) ZZ[coeff]] = value * pjd->qtab[qtabidx][coeff];
+                                        }
+                                    }
+
+                                    // do IDCT
+
+                                    // output block's upper-left
+                                    // coordinate (in pixels) is
+                                    // (comp_x, comp_y).
+                                    uint32_t comp_x = (mcu_x * comp->scalex + sbx) * 8;
+                                    uint32_t comp_y = (mcu_y * comp->scaley + sby) * 8;
+                                    uint32_t dataidx = comp_y * comp->stride + comp_x;
+
+//                                    pjpeg_idct_2D_u32(block, &comp->data[dataidx], comp->stride);
+                                    pjpeg_idct_2D_nanojpeg(block, &comp->data[dataidx], comp->stride);
+                                }
+                            }
+                        }
+
+                        pjd->reset_count++;
+//                        printf("%04x: reset count %d / %d\n", pjd->inpos, pjd->reset_count, pjd->reset_interval);
+
+                    }
+                }
+
+                free(dcpred);
+                free(comp_idx);
+
+                break;
+            }
+
+            case 0xd9: { // EOI End of Image
+                goto got_end_of_image;
+            }
+
+            case 0xdd: { // Define Restart Interval
+                uint16_t length = bd_consume_bits(&bd, 16);
+                if (length != 4)
+                    return PJPEG_ERR_DRI;
+
+                // reset interval measured in the number of MCUs
+                pjd->reset_interval = bd_consume_bits(&bd, 16);
+
+                break;
+            }
+
+            default: {
+                printf("pjepg: Unknown marker %02x at offset %04x\n", marker, marker_offset);
+
+                // try to skip it.
+                uint16_t length = bd_consume_bits(&bd, 16);
+                bd_discard_bytes(&bd, length - 2);
+                continue;
+            }
+        } // switch (marker)
+    } // while inpos < inlen
+
+  got_end_of_image:
+
+    return PJPEG_OKAY;
+}
+
+void pjpeg_destroy(pjpeg_t *pj)
+{
+    if (!pj)
+        return;
+
+    for (int i = 0; i < pj->ncomponents; i++)
+        free(pj->components[i].data);
+    free(pj->components);
+
+    free(pj);
+}
+
+
+// just grab the first component.
+image_u8_t *pjpeg_to_u8_baseline(pjpeg_t *pj)
+{
+    assert(pj->ncomponents > 0);
+
+    pjpeg_component_t *comp = &pj->components[0];
+
+    assert(comp->width >= pj->width && comp->height >= pj->height);
+
+    image_u8_t *im = image_u8_create(pj->width, pj->height);
+    for (int y = 0; y < im->height; y++)
+        memcpy(&im->buf[y*im->stride], &comp->data[y*comp->stride], pj->width);
+
+    return im;
+}
+
+static inline uint8_t clampd(double v)
+{
+    if (v < 0)
+        return 0;
+    if (v > 255)
+        return 255;
+
+    return (uint8_t) v;
+}
+
+static inline uint8_t clamp_u8(int32_t v)
+{
+    if (v < 0)
+        return 0;
+    if (v > 255)
+        return 255;
+    return v;
+}
+
+// color conversion formulas taken from JFIF spec v 1.02
+image_u8x3_t *pjpeg_to_u8x3_baseline(pjpeg_t *pj)
+{
+    assert(pj->ncomponents == 3);
+
+    pjpeg_component_t *Y = &pj->components[0];
+    pjpeg_component_t *Cb = &pj->components[1];
+    pjpeg_component_t *Cr = &pj->components[2];
+
+    int Cb_factor_y = Y->height / Cb->height;
+    int Cb_factor_x = Y->width / Cb->width;
+
+    int Cr_factor_y = Y->height / Cr->height;
+    int Cr_factor_x = Y->width / Cr->width;
+
+    image_u8x3_t *im = image_u8x3_create(pj->width, pj->height);
+
+    if (Cr_factor_y == 1 && Cr_factor_x == 1 && Cb_factor_y == 1 && Cb_factor_x == 1) {
+
+        for (int y = 0; y < pj->height; y++) {
+            for (int x = 0; x < pj->width; x++) {
+                int32_t y_val  = Y->data[y*Y->stride + x] * 65536;
+                int32_t cb_val = Cb->data[y*Cb->stride + x] - 128;
+                int32_t cr_val = Cr->data[y*Cr->stride + x] - 128;
+
+                int32_t r_val = y_val +  91881 * cr_val;
+                int32_t g_val = y_val + -22554 * cb_val - 46802 * cr_val;
+                int32_t b_val = y_val + 116130 * cb_val;
+
+                im->buf[y*im->stride + 3*x + 0 ] = clamp_u8(r_val >> 16);
+                im->buf[y*im->stride + 3*x + 1 ] = clamp_u8(g_val >> 16);
+                im->buf[y*im->stride + 3*x + 2 ] = clamp_u8(b_val >> 16);
+            }
+        }
+    } else if (Cb_factor_y == Cr_factor_y && Cb_factor_x == Cr_factor_x) {
+        for (int by = 0; by < pj->height / Cb_factor_y; by++) {
+            for (int bx = 0; bx < pj->width / Cb_factor_x; bx++) {
+
+                int32_t cb_val = Cb->data[by*Cb->stride + bx] - 128;
+                int32_t cr_val = Cr->data[by*Cr->stride + bx] - 128;
+
+                int32_t r0 =  91881 * cr_val;
+                int32_t g0 = -22554 * cb_val - 46802 * cr_val;
+                int32_t b0 = 116130 * cb_val;
+
+                for (int dy = 0; dy < Cb_factor_y; dy++) {
+                    int y = by*Cb_factor_y + dy;
+
+                    for (int dx = 0; dx < Cb_factor_x; dx++) {
+                        int x = bx*Cb_factor_x + dx;
+
+                        int32_t y_val = Y->data[y*Y->stride + x] * 65536;
+
+                        int32_t r_val = r0 + y_val;
+                        int32_t g_val = g0 + y_val;
+                        int32_t b_val = b0 + y_val;
+
+                        im->buf[y*im->stride + 3*x + 0 ] = clamp_u8(r_val >> 16);
+                        im->buf[y*im->stride + 3*x + 1 ] = clamp_u8(g_val >> 16);
+                        im->buf[y*im->stride + 3*x + 2 ] = clamp_u8(b_val >> 16);
+                    }
+                }
+            }
+        }
+    } else {
+
+        for (int y = 0; y < pj->height; y++) {
+            for (int x = 0; x < pj->width; x++) {
+                int32_t y_val  = Y->data[y*Y->stride + x];
+                int32_t cb_val = Cb->data[(y / Cb_factor_y)*Cb->stride + (x / Cb_factor_x)] - 128;
+                int32_t cr_val = Cr->data[(y / Cr_factor_y)*Cr->stride + (x / Cr_factor_x)] - 128;
+
+                uint8_t r_val = clampd(y_val + 1.402 * cr_val);
+                uint8_t g_val = clampd(y_val - 0.34414 * cb_val - 0.71414 * cr_val);
+                uint8_t b_val = clampd(y_val + 1.772 * cb_val);
+
+                im->buf[y*im->stride + 3*x + 0 ] = r_val;
+                im->buf[y*im->stride + 3*x + 1 ] = g_val;
+                im->buf[y*im->stride + 3*x + 2 ] = b_val;
+            }
+        }
+    }
+
+    return im;
+}
+
+///////////////////////////////////////////////////////////////////
+// returns NULL if file loading fails.
+pjpeg_t *pjpeg_create_from_file(const char *path, uint32_t flags, int *error)
+{
+    FILE *f = fopen(path, "rb");
+    if (f == NULL)
+        return NULL;
+
+    fseek(f, 0, SEEK_END);
+    long buflen = ftell(f);
+
+    uint8_t *buf = malloc(buflen);
+    fseek(f, 0, SEEK_SET);
+    int res = fread(buf, 1, buflen, f);
+
+    if ( ferror(f) ){
+        debug_print ("Read failed");
+        clearerr(f);
+    }
+
+    fclose(f);
+    if (res != buflen) {
+        free(buf);
+        if (error)
+            *error = PJPEG_ERR_FILE;
+        return NULL;
+    }
+
+    pjpeg_t *pj = pjpeg_create_from_buffer(buf, buflen, flags, error);
+
+    free(buf);
+    return pj;
+}
+
+pjpeg_t *pjpeg_create_from_buffer(uint8_t *buf, int buflen, uint32_t flags, int *error)
+{
+    struct pjpeg_decode_state pjd;
+    memset(&pjd, 0, sizeof(pjd));
+
+    if (flags & PJPEG_MJPEG) {
+        pjd.in = mjpeg_dht;
+        pjd.inlen = sizeof(mjpeg_dht);
+        int result = pjpeg_decode_buffer(&pjd);
+        (void) result;
+        assert(result == 0);
+    }
+
+    pjd.in = buf;
+    pjd.inlen = buflen;
+    pjd.flags = flags;
+
+    int result = pjpeg_decode_buffer(&pjd);
+    if (error)
+        *error = result;
+
+    if (result) {
+        for (int i = 0; i < pjd.ncomponents; i++)
+            free(pjd.components[i].data);
+        free(pjd.components);
+
+        return NULL;
+    }
+
+    pjpeg_t *pj = calloc(1, sizeof(pjpeg_t));
+
+    pj->width = pjd.width;
+    pj->height = pjd.height;
+    pj->ncomponents = pjd.ncomponents;
+    pj->components = pjd.components;
+
+    return pj;
+}

--- a/common/pjpeg.h
+++ b/common/pjpeg.h
@@ -1,0 +1,103 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+
+#pragma once
+
+#include "image_u8.h"
+#include "image_u8x3.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct pjpeg_component pjpeg_component_t;
+struct pjpeg_component
+{
+    // resolution of this component (which is smaller than the
+    // dimensions of the image if the channel has been sub-sampled.)
+    uint32_t width, height;
+
+    // number of bytes per row. May be larger than width for alignment
+    // reasons.
+    uint32_t stride;
+
+    // data[y*stride + x]
+    uint8_t *data;
+
+    ////////////////////////////////////////////////////////////////
+    // These items probably not of great interest to most
+    // applications.
+    uint8_t id; // the identifier associated with this component
+    uint8_t hv; // horiz scale (high 4 bits) / vert scale (low 4 bits)
+    uint8_t scalex, scaley; // derived from hv above
+    uint8_t tq; // quantization table index
+
+    // this filled in at the last moment by SOS
+    uint8_t tda; // which huff tables will we use for DC (high 4 bits) and AC (low 4 bits)
+};
+
+typedef struct pjpeg pjpeg_t;
+struct pjpeg
+{
+    // status of the decode is put here. Non-zero means error.
+    int error;
+
+    uint32_t width, height; // pixel dimensions
+
+    int ncomponents;
+    pjpeg_component_t *components;
+};
+
+enum PJPEG_FLAGS {
+    PJPEG_STRICT = 1,  // Don't try to recover from errors.
+    PJPEG_MJPEG = 2,   // Support JPGs with missing DHT segments.
+};
+
+enum PJPEG_ERROR {
+    PJPEG_OKAY = 0,
+    PJPEG_ERR_FILE, // something wrong reading file
+    PJPEG_ERR_DQT, // something wrong with DQT marker
+    PJPEG_ERR_SOF, // something wrong with SOF marker
+    PJPEG_ERR_DHT, // something wrong with DHT marker
+    PJPEG_ERR_SOS, // something wrong with SOS marker
+    PJPEG_ERR_MISSING_DHT, // missing a necessary huffman table
+    PJPEG_ERR_DRI, // something wrong with DRI marker
+    PJPEG_ERR_RESET, // didn't get a reset marker where we expected. Corruption?
+    PJPEG_ERR_EOF, // ran out of bytes while decoding
+    PJEPG_ERR_UNSUPPORTED, // an unsupported format
+};
+
+pjpeg_t *pjpeg_create_from_file(const char *path, uint32_t flags, int *error);
+pjpeg_t *pjpeg_create_from_buffer(uint8_t *buf, int buflen, uint32_t flags, int *error);
+void pjpeg_destroy(pjpeg_t *pj);
+
+image_u8_t *pjpeg_to_u8_baseline(pjpeg_t *pj);
+image_u8x3_t *pjpeg_to_u8x3_baseline(pjpeg_t *pj);
+
+#ifdef __cplusplus
+}
+#endif

--- a/common/string_util.c
+++ b/common/string_util.c
@@ -1,0 +1,772 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+
+#include <assert.h>
+#include <ctype.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "string_util.h"
+#include "zarray.h"
+
+struct string_buffer
+{
+    char *s;
+    int alloc;
+    size_t size; // as if strlen() was called; not counting terminating \0
+};
+
+#define MIN_PRINTF_ALLOC 16
+
+char *sprintf_alloc(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+
+    va_start(args,fmt);
+    char *buf = vsprintf_alloc(fmt, args);
+    va_end(args);
+
+    return buf;
+}
+
+char *vsprintf_alloc(const char *fmt, va_list orig_args)
+{
+    assert(fmt != NULL);
+
+    int size = MIN_PRINTF_ALLOC;
+    char *buf = malloc(size * sizeof(char));
+
+    int returnsize;
+    va_list args;
+
+    va_copy(args, orig_args);
+    returnsize = vsnprintf(buf, size, fmt, args);
+    va_end(args);
+
+    // it was successful
+    if (returnsize < size) {
+        return buf;
+    }
+
+    // otherwise, we should try again
+    free(buf);
+    size = returnsize + 1;
+    buf = malloc(size * sizeof(char));
+
+    va_copy(args, orig_args);
+    returnsize = vsnprintf(buf, size, fmt, args);
+    va_end(args);
+
+    assert(returnsize <= size);
+    return buf;
+}
+
+char *_str_concat_private(const char *first, ...)
+{
+    size_t len = 0;
+
+    // get the total length (for the allocation)
+    {
+        va_list args;
+        va_start(args, first);
+        const char *arg = first;
+        while(arg != NULL) {
+            len += strlen(arg);
+            arg = va_arg(args, const char *);
+        }
+        va_end(args);
+    }
+
+    // write the string
+    char *str = malloc(len*sizeof(char) + 1);
+    char *ptr = str;
+    {
+        va_list args;
+        va_start(args, first);
+        const char *arg = first;
+        while(arg != NULL) {
+            while(*arg)
+                *ptr++ = *arg++;
+            arg = va_arg(args, const char *);
+        }
+        *ptr = '\0';
+        va_end(args);
+    }
+
+    return str;
+}
+
+// Returns the index of the first character that differs:
+int str_diff_idx(const char * a, const char * b)
+{
+    assert(a != NULL);
+    assert(b != NULL);
+
+    int i = 0;
+
+    size_t lena = strlen(a);
+    size_t lenb = strlen(b);
+
+    size_t minlen = lena < lenb ? lena : lenb;
+
+    for (; i < minlen; i++)
+        if (a[i] != b[i])
+            break;
+
+    return i;
+}
+
+
+zarray_t *str_split(const char *str, const char *delim)
+{
+    assert(str != NULL);
+    assert(delim != NULL);
+
+    zarray_t *parts = zarray_create(sizeof(char*));
+    string_buffer_t *sb = string_buffer_create();
+
+    size_t delim_len = strlen(delim);
+    size_t len = strlen(str);
+    size_t pos = 0;
+
+    while (pos < len) {
+        if (str_starts_with(&str[pos], delim) && delim_len > 0) {
+            pos += delim_len;
+            // never add empty strings (repeated tokens)
+            if (string_buffer_size(sb) > 0) {
+                char *part = string_buffer_to_string(sb);
+                zarray_add(parts, &part);
+            }
+            string_buffer_reset(sb);
+        } else {
+            string_buffer_append(sb, str[pos]);
+            pos++;
+        }
+    }
+
+    if (string_buffer_size(sb) > 0) {
+        char *part = string_buffer_to_string(sb);
+        zarray_add(parts, &part);
+    }
+
+    string_buffer_destroy(sb);
+    return parts;
+}
+
+// split on one or more spaces.
+zarray_t *str_split_spaces(const char *str)
+{
+  zarray_t *parts = zarray_create(sizeof(char*));
+  size_t len = strlen(str);
+  size_t pos = 0;
+
+  while (pos < len) {
+
+    while (pos < len && str[pos] == ' ')
+      pos++;
+
+    // produce a token?
+    if (pos < len) {
+      // yes!
+      size_t off0 = pos;
+      while (pos < len && str[pos] != ' ')
+	pos++;
+      size_t off1 = pos;
+
+      size_t len_off = off1 - off0;
+      char *tok = malloc(len_off + 1);
+      memcpy(tok, &str[off0], len_off);
+      tok[len_off] = 0;
+      zarray_add(parts, &tok);
+    }
+  }
+
+  return parts;
+}
+
+void str_split_destroy(zarray_t *za)
+{
+    if (!za)
+        return;
+
+    zarray_vmap(za, free);
+    zarray_destroy(za);
+}
+
+char *str_trim(char *str)
+{
+    assert(str != NULL);
+
+    return str_lstrip(str_rstrip(str));
+}
+
+char *str_lstrip(char *str)
+{
+    assert(str != NULL);
+
+    char *ptr = str;
+    char *end = str + strlen(str);
+    for(; ptr != end && isspace(*ptr); ptr++);
+    // shift the string to the left so the original pointer still works
+    memmove(str, ptr, strlen(ptr)+1);
+    return str;
+}
+
+char *str_rstrip(char *str)
+{
+    assert(str != NULL);
+
+    char *ptr = str + strlen(str) - 1;
+    for(; ptr+1 != str && isspace(*ptr); ptr--);
+    *(ptr+1) = '\0';
+    return str;
+}
+
+int str_indexof(const char *haystack, const char *needle)
+{
+	assert(haystack != NULL);
+	assert(needle != NULL);
+
+    // use signed types for hlen/nlen because hlen - nlen can be negative.
+    int hlen = (int) strlen(haystack);
+    int nlen = (int) strlen(needle);
+
+    if (nlen > hlen) return -1;
+
+    for (int i = 0; i <= hlen - nlen; i++) {
+        if (!strncmp(&haystack[i], needle, nlen))
+            return i;
+    }
+
+    return -1;
+}
+
+int str_last_indexof(const char *haystack, const char *needle)
+{
+	assert(haystack != NULL);
+	assert(needle != NULL);
+
+    // use signed types for hlen/nlen because hlen - nlen can be negative.
+    int hlen = (int) strlen(haystack);
+    int nlen = (int) strlen(needle);
+
+    int last_index = -1;
+    for (int i = 0; i <= hlen - nlen; i++) {
+        if (!strncmp(&haystack[i], needle, nlen))
+            last_index = i;
+    }
+
+    return last_index;
+}
+
+// in-place modification.
+char *str_tolowercase(char *s)
+{
+	assert(s != NULL);
+
+    size_t slen = strlen(s);
+    for (int i = 0; i < slen; i++) {
+        if (s[i] >= 'A' && s[i] <= 'Z')
+            s[i] = s[i] + 'a' - 'A';
+    }
+
+    return s;
+}
+
+char *str_touppercase(char *s)
+{
+    assert(s != NULL);
+
+    size_t slen = strlen(s);
+    for (int i = 0; i < slen; i++) {
+        if (s[i] >= 'a' && s[i] <= 'z')
+            s[i] = s[i] - ('a' - 'A');
+    }
+
+    return s;
+}
+
+string_buffer_t* string_buffer_create()
+{
+    string_buffer_t *sb = (string_buffer_t*) calloc(1, sizeof(string_buffer_t));
+    assert(sb != NULL);
+    sb->alloc = 32;
+    sb->s = calloc(sb->alloc, 1);
+    return sb;
+}
+
+void string_buffer_destroy(string_buffer_t *sb)
+{
+    if (sb == NULL)
+        return;
+
+    if (sb->s)
+        free(sb->s);
+
+    memset(sb, 0, sizeof(string_buffer_t));
+    free(sb);
+}
+
+void string_buffer_append(string_buffer_t *sb, char c)
+{
+    assert(sb != NULL);
+
+    if (sb->size+2 >= sb->alloc) {
+        sb->alloc *= 2;
+        sb->s = realloc(sb->s, sb->alloc);
+    }
+
+    sb->s[sb->size++] = c;
+    sb->s[sb->size] = 0;
+}
+
+char string_buffer_pop_back(string_buffer_t *sb) {
+    assert(sb != NULL);
+    if (sb->size == 0)
+        return 0;
+
+    char back = sb->s[--sb->size];
+    sb->s[sb->size] = 0;
+    return back;
+}
+
+void string_buffer_appendf(string_buffer_t *sb, const char *fmt, ...)
+{
+    assert(sb != NULL);
+    assert(fmt != NULL);
+
+    int size = MIN_PRINTF_ALLOC;
+    char *buf = malloc(size * sizeof(char));
+
+    int returnsize;
+    va_list args;
+
+    va_start(args,fmt);
+    returnsize = vsnprintf(buf, size, fmt, args);
+    va_end(args);
+
+    if (returnsize >= size) {
+        // otherwise, we should try again
+        free(buf);
+        size = returnsize + 1;
+        buf = malloc(size * sizeof(char));
+
+        va_start(args, fmt);
+        returnsize = vsnprintf(buf, size, fmt, args);
+        va_end(args);
+
+        assert(returnsize <= size);
+    }
+
+    string_buffer_append_string(sb, buf);
+    free(buf);
+}
+
+void string_buffer_append_string(string_buffer_t *sb, const char *str)
+{
+    assert(sb != NULL);
+    assert(str != NULL);
+
+    size_t len = strlen(str);
+
+    while (sb->size+len + 1 >= sb->alloc) {
+        sb->alloc *= 2;
+        sb->s = realloc(sb->s, sb->alloc);
+    }
+
+    memcpy(&sb->s[sb->size], str, len);
+    sb->size += len;
+    sb->s[sb->size] = 0;
+}
+
+bool string_buffer_ends_with(string_buffer_t *sb, const char *str)
+{
+    assert(sb != NULL);
+    assert(str != NULL);
+
+    return str_ends_with(sb->s, str);
+}
+
+char *string_buffer_to_string(string_buffer_t *sb)
+{
+    assert(sb != NULL);
+
+    return strdup(sb->s);
+}
+
+// returns length of string (not counting \0)
+size_t string_buffer_size(string_buffer_t *sb)
+{
+    assert(sb != NULL);
+
+    return sb->size;
+}
+
+void string_buffer_reset(string_buffer_t *sb)
+{
+    assert(sb != NULL);
+
+    sb->s[0] = 0;
+    sb->size = 0;
+}
+
+string_feeder_t *string_feeder_create(const char *str)
+{
+    assert(str != NULL);
+
+    string_feeder_t *sf = (string_feeder_t*) calloc(1, sizeof(string_feeder_t));
+    sf->s = strdup(str);
+    sf->len = strlen(sf->s);
+    sf->line = 1;
+    sf->col = 0;
+    sf->pos = 0;
+    return sf;
+}
+
+int string_feeder_get_line(string_feeder_t *sf)
+{
+    assert(sf != NULL);
+    return sf->line;
+}
+
+int string_feeder_get_column(string_feeder_t *sf)
+{
+    assert(sf != NULL);
+    return sf->col;
+}
+
+void string_feeder_destroy(string_feeder_t *sf)
+{
+    if (sf == NULL)
+        return;
+
+    free(sf->s);
+    memset(sf, 0, sizeof(string_feeder_t));
+    free(sf);
+}
+
+bool string_feeder_has_next(string_feeder_t *sf)
+{
+    assert(sf != NULL);
+
+    return sf->s[sf->pos] != 0 && sf->pos <= sf->len;
+}
+
+char string_feeder_next(string_feeder_t *sf)
+{
+    assert(sf != NULL);
+    assert(sf->pos <= sf->len);
+
+    char c = sf->s[sf->pos++];
+    if (c == '\n') {
+        sf->line++;
+        sf->col = 0;
+    } else {
+        sf->col++;
+    }
+
+    return c;
+}
+
+char *string_feeder_next_length(string_feeder_t *sf, size_t length)
+{
+    assert(sf != NULL);
+    assert(length >= 0);
+    assert(sf->pos <= sf->len);
+
+    if (sf->pos + length > sf->len)
+        length = sf->len - sf->pos;
+
+    char *substr = calloc(length+1, sizeof(char));
+    for (int i = 0 ; i < length ; i++)
+        substr[i] = string_feeder_next(sf);
+    return substr;
+}
+
+char string_feeder_peek(string_feeder_t *sf)
+{
+    assert(sf != NULL);
+    assert(sf->pos <= sf->len);
+
+    return sf->s[sf->pos];
+}
+
+char *string_feeder_peek_length(string_feeder_t *sf, size_t length)
+{
+    assert(sf != NULL);
+    assert(length >= 0);
+    assert(sf->pos <= sf->len);
+
+    if (sf->pos + length > sf->len)
+        length = sf->len - sf->pos;
+
+    char *substr = calloc(length+1, sizeof(char));
+    memcpy(substr, &sf->s[sf->pos], length*sizeof(char));
+    return substr;
+}
+
+bool string_feeder_starts_with(string_feeder_t *sf, const char *str)
+{
+    assert(sf != NULL);
+    assert(str != NULL);
+    assert(sf->pos <= sf->len);
+
+    return str_starts_with(&sf->s[sf->pos], str);
+}
+
+void string_feeder_require(string_feeder_t *sf, const char *str)
+{
+    assert(sf != NULL);
+    assert(str != NULL);
+    assert(sf->pos <= sf->len);
+
+    size_t len = strlen(str);
+
+    for (int i = 0; i < len; i++) {
+        char c = string_feeder_next(sf);
+        (void) c;
+        assert(c == str[i]);
+    }
+}
+
+////////////////////////////////////////////
+bool str_ends_with(const char *haystack, const char *needle)
+{
+    assert(haystack != NULL);
+    assert(needle != NULL);
+
+    size_t lens = strlen(haystack);
+    size_t lenneedle = strlen(needle);
+
+    if (lenneedle > lens)
+        return false;
+
+    return !strncmp(&haystack[lens - lenneedle], needle, lenneedle);
+}
+
+#ifndef _MSC_VER
+inline
+#endif
+bool str_starts_with(const char *haystack, const char *needle)
+{
+    assert(haystack != NULL);
+    assert(needle != NULL);
+
+    // haystack[pos] doesn't have to be compared to zero; if it were
+    // zero, it either doesn't match needle (in which case the loop
+    // terminates) or it matches needle[pos] (in which case the loop
+    // terminates).
+    int pos = 0;
+    while (haystack[pos] == needle[pos] && needle[pos] != 0)
+        pos++;
+
+    return (needle[pos] == 0);
+}
+
+bool str_starts_with_any(const char *haystack, const char **needles, int num_needles)
+{
+    assert(haystack != NULL);
+    assert(needles != NULL);
+    assert(num_needles >= 0);
+
+    for (int i = 0; i < num_needles; i++) {
+        assert(needles[i] != NULL);
+        if (str_starts_with(haystack, needles[i]))
+            return true;
+    }
+
+    return false;
+}
+
+bool str_matches_any(const char *haystack, const char **needles, int num_needles)
+{
+    assert(haystack != NULL);
+    assert(needles != NULL);
+    assert(num_needles >= 0);
+
+    for (int i = 0; i < num_needles; i++) {
+        assert(needles[i] != NULL);
+        if (!strcmp(haystack, needles[i]))
+            return true;
+    }
+
+    return false;
+}
+
+char *str_substring(const char *str, size_t startidx, long endidx)
+{
+    assert(str != NULL);
+    assert(startidx >= 0 && startidx <= strlen(str)+1);
+    assert(endidx < 0 || endidx >= startidx);
+    assert(endidx < 0 || endidx <= strlen(str)+1);
+
+    if (endidx < 0)
+        endidx = (long) strlen(str);
+
+    size_t blen = endidx - startidx; // not counting \0
+    char *b = malloc(blen + 1);
+    memcpy(b, &str[startidx], blen);
+    b[blen] = 0;
+    return b;
+}
+
+char *str_replace(const char *haystack, const char *needle, const char *replacement)
+{
+    assert(haystack != NULL);
+    assert(needle != NULL);
+    assert(replacement != NULL);
+
+    string_buffer_t *sb = string_buffer_create();
+    size_t haystack_len = strlen(haystack);
+    size_t needle_len = strlen(needle);
+
+    int pos = 0;
+    while (pos < haystack_len) {
+        if (needle_len > 0 && str_starts_with(&haystack[pos], needle)) {
+            string_buffer_append_string(sb, replacement);
+            pos += needle_len;
+        } else {
+            string_buffer_append(sb, haystack[pos]);
+            pos++;
+        }
+    }
+    if (needle_len == 0 && haystack_len == 0)
+        string_buffer_append_string(sb, replacement);
+
+    char *res = string_buffer_to_string(sb);
+    string_buffer_destroy(sb);
+    return res;
+}
+
+char *str_replace_many(const char *_haystack, ...)
+{
+    va_list ap;
+    va_start(ap, _haystack);
+
+    char *haystack = strdup(_haystack);
+
+    while (true) {
+        char *needle = va_arg(ap, char*);
+        if (!needle)
+            break;
+
+        char *replacement = va_arg(ap, char*);
+        char *tmp = str_replace(haystack, needle, replacement);
+        free(haystack);
+        haystack = tmp;
+    }
+
+    va_end(ap);
+
+    return haystack;
+}
+
+static void buffer_appendf(char **_buf, int *bufpos, void *fmt, ...)
+{
+    char *buf = *_buf;
+    va_list ap;
+
+    int salloc = 128;
+    char *s = malloc(salloc);
+
+    va_start(ap, fmt);
+    int slen = vsnprintf(s, salloc, fmt, ap);
+    va_end(ap);
+
+    if (slen >= salloc) {
+        s = realloc(s, slen + 1);
+        va_start(ap, fmt);
+        vsprintf((char*) s, fmt, ap);
+        va_end(ap);
+    }
+
+    buf = realloc(buf, *bufpos + slen + 1);
+    *_buf = buf;
+
+    memcpy(&buf[*bufpos], s, slen + 1); // get trailing \0
+    (*bufpos) += slen;
+
+    free(s);
+}
+
+static int is_variable_character(char c)
+{
+    if (c >= 'a' && c <= 'z')
+        return 1;
+
+    if (c >= 'A' && c <= 'Z')
+        return 1;
+
+    if (c >= '0' && c <= '9')
+        return 1;
+
+    if (c == '_')
+        return 1;
+
+    return 0;
+}
+
+char *str_expand_envs(const char *in)
+{
+    size_t inlen = strlen(in);
+    size_t inpos = 0;
+
+    char *out = NULL;
+    int  outpos = 0;
+
+    while (inpos < inlen) {
+
+        if (in[inpos] != '$') {
+            buffer_appendf(&out, &outpos, "%c", in[inpos]);
+            inpos++;
+            continue;
+
+        } else {
+            inpos++; // consume '$'
+
+            char *varname = NULL;
+            int  varnamepos = 0;
+
+            while (inpos < inlen && is_variable_character(in[inpos])) {
+                buffer_appendf(&varname, &varnamepos, "%c", in[inpos]);
+                inpos++;
+            }
+
+            char *env = getenv(varname);
+            if (env)
+                buffer_appendf(&out, &outpos, "%s", env);
+
+            free(varname);
+        }
+    }
+
+    return out;
+}

--- a/common/string_util.h
+++ b/common/string_util.h
@@ -1,0 +1,465 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+
+#pragma once
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <ctype.h>
+
+#include "zarray.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+typedef struct string_buffer string_buffer_t;
+
+typedef struct string_feeder string_feeder_t;
+struct string_feeder
+{
+    char *s;
+    size_t len;
+    size_t pos;
+
+    int line, col;
+};
+
+/**
+ * Similar to sprintf(), except that it will malloc() enough space for the
+ * formatted string which it returns. It is the caller's responsibility to call
+ * free() on the returned string when it is no longer needed.
+ */
+char *sprintf_alloc(const char *fmt, ...)
+#ifndef _MSC_VER
+__attribute__ ((format (printf, 1, 2)))
+#endif
+;
+
+/**
+ * Similar to vsprintf(), except that it will malloc() enough space for the
+ * formatted string which it returns. It is the caller's responsibility to call
+ * free() on the returned string when it is no longer needed.
+ */
+char *vsprintf_alloc(const char *fmt, va_list args);
+
+/**
+ * Concatenates 1 or more strings together and returns the result, which will be a
+ * newly allocated string which it is the caller's responsibility to free.
+ */
+#define str_concat(...) _str_concat_private(__VA_ARGS__, NULL)
+char *_str_concat_private(const char *first, ...);
+
+
+// Returns the index of the first character that differs:
+int str_diff_idx(const char * a, const char * b);
+
+/**
+ * Splits the supplied string into an array of strings by subdividing it at
+ * each occurrence of the supplied delimiter string. The split strings will not
+ * contain the delimiter. The original string will remain unchanged.
+ * If str is composed of all delimiters, an empty array will be returned.
+ *
+ * It is the caller's responsibilty to free the returned zarray, as well as
+ * the strings contained within it, e.g.:
+ *
+ *   zarray_t *za = str_split("this is a haystack", " ");
+ *      => ["this", "is", "a", "haystack"]
+ *   zarray_vmap(za, free);
+ *   zarray_destroy(za);
+ */
+zarray_t *str_split(const char *str, const char *delim);
+
+zarray_t *str_split_spaces(const char *str);
+
+void str_split_destroy(zarray_t *s);
+
+/*
+ * Determines if str1 exactly matches str2 (more efficient than strcmp(...) == 0)
+ */
+static inline bool streq(const char *str1, const char* str2)
+{
+    int i;
+    for (i = 0 ; str1[i] != '\0' ; i++) {
+        if (str1[i] != str2[i])
+            return false;
+    }
+
+    return str2[i] == '\0';
+}
+
+/**
+ * Determines if str1 exactly matches str2, ignoring case (more efficient than
+ * strcasecmp(...) == 0)
+ */
+static inline bool strcaseeq(const char *str1, const char* str2)
+{
+    int i;
+    for (i = 0 ; str1[i] != '\0' ; i++) {
+        if (str1[i] == str2[i])
+            continue;
+        else if (islower(str1[i]) && (str1[i] - 32) == str2[i])
+            continue;
+        else if (isupper(str1[i]) && (str1[i] + 32) == str2[i])
+            continue;
+
+        return false;
+    }
+
+    return str2[i] == '\0';
+}
+
+/**
+ * Trims whitespace characters (i.e. matching isspace()) from the beginning and/or
+ * end of the supplied string. This change affects the supplied string in-place.
+ * The supplied/edited string is returned to enable chained reference.
+ *
+ * Note: do not pass a string literal to this function
+ */
+char *str_trim(char *str);
+
+/**
+ * Trims whitespace characters (i.e. matching isspace()) from the beginning
+ * of the supplied string. This change affects the supplied string in-place.
+ * The supplied/edited string is returned to enable chained reference.
+ *
+ * Note: do not pass a string literal to this function
+ */
+char *str_lstrip(char *str);
+
+/**
+ * Trims whitespace characters (i.e. matching isspace()) from the end of the
+ * supplied string. This change affects the supplied string in-place.
+ * The supplied/edited string is returned to enable chained reference.
+ *
+ * Note: do not pass a string literal to this function
+ */
+char *str_rstrip(char *str);
+
+/**
+ * Returns true if the end of string 'haystack' matches 'needle', else false.
+ *
+ * Note: An empty needle ("") will match any source.
+ */
+bool str_ends_with(const char *haystack, const char *needle);
+
+/**
+ * Returns true if the start of string 'haystack' matches 'needle', else false.
+ *
+ * Note: An empty needle ("") will match any source.
+ */
+bool str_starts_with(const char *haystack, const char *needle);
+
+/**
+ * Returns true if the start of string 'haystack' matches any needle, else false.
+ *
+ * Note: An empty needle ("") will match any source.
+ */
+bool str_starts_with_any(const char *haystack, const char **needles, int num_needles);
+
+/**
+ * Returns true if the string 'haystack' matches any needle, else false.
+ */
+bool str_matches_any(const char *haystack, const char **needles, int num_needles);
+
+/**
+ * Retrieves a (newly-allocated) substring of the given string, 'str', starting
+ * from character index 'startidx' through index 'endidx' - 1 (inclusive).
+ * An 'endidx' value -1 is equivalent to strlen(str).
+ *
+ * It is the caller's responsibility to free the returned string.
+ *
+ * Examples:
+ *   str_substring("string", 1, 3) = "tr"
+ *   str_substring("string", 2, -1) = "ring"
+ *   str_substring("string", 3, 3) = ""
+ *
+ * Note: startidx must be >= endidx
+ */
+char *str_substring(const char *str, size_t startidx, long endidx);
+
+/**
+ * Retrieves the zero-based index of the beginning of the supplied substring
+ * (needle) within the search string (haystack) if it exists.
+ *
+ * Returns -1 if the supplied needle is not found within the haystack.
+ */
+int str_indexof(const char *haystack, const char *needle);
+
+    static inline int str_contains(const char *haystack, const char *needle) {
+        return str_indexof(haystack, needle) >= 0;
+    }
+
+// same as above, but returns last match
+int str_last_indexof(const char *haystack, const char *needle);
+
+/**
+ * Replaces all upper-case characters within the supplied string with their
+ * lower-case counterparts, modifying the original string's contents.
+ *
+ * Returns the supplied / modified string.
+ */
+char *str_tolowercase(char *s);
+
+/**
+ * Replaces all lower-case characters within the supplied string with their
+ * upper-case counterparts, modifying the original string's contents.
+ *
+ * Returns the supplied / modified string.
+ */
+char *str_touppercase(char *s);
+
+/**
+ * Replaces all occurrences of 'needle' in the string 'haystack', substituting
+ * for them the value of 'replacement', and returns the result as a newly-allocated
+ * string. The original strings remain unchanged.
+ *
+ * It is the caller's responsibility to free the returned string.
+ *
+ * Examples:
+ *   str_replace("string", "ri", "u") = "stung"
+ *   str_replace("singing", "ing", "") = "s"
+ *   str_replace("string", "foo", "bar") = "string"
+ *
+ * Note: An empty needle will match only an empty haystack
+ */
+char *str_replace(const char *haystack, const char *needle, const char *replacement);
+
+    char *str_replace_many(const char *_haystack, ...);
+//////////////////////////////////////////////////////
+// String Buffer
+
+/**
+ * Creates and initializes a string buffer object which can be used with any of
+ * the string_buffer_*() functions.
+ *
+ * It is the caller's responsibility to free the string buffer resources with
+ * a call to string_buffer_destroy() when it is no longer needed.
+ */
+string_buffer_t *string_buffer_create();
+
+/**
+ * Frees the resources associated with a string buffer object, including space
+ * allocated for any appended characters / strings.
+ */
+void string_buffer_destroy(string_buffer_t *sb);
+
+/**
+ * Appends a single character to the end of the supplied string buffer.
+ */
+void string_buffer_append(string_buffer_t *sb, char c);
+
+/**
+ * Removes a single character from the end of the string and
+ * returns it. Does nothing if string is empty and returns NULL
+ */
+char string_buffer_pop_back(string_buffer_t *sb);
+
+/**
+ * Appends the supplied string to the end of the supplied string buffer.
+ */
+void string_buffer_append_string(string_buffer_t *sb, const char *str);
+
+/**
+ * Formats the supplied string and arguments in a manner akin to printf(), and
+ * appends the resulting string to the end of the supplied string buffer.
+ */
+void string_buffer_appendf(string_buffer_t *sb, const char *fmt, ...)
+#ifndef _MSC_VER
+__attribute__ ((format (printf, 2, 3)))
+#endif
+;
+
+/**
+ * Determines whether the character contents held by the supplied string buffer
+ * ends with the supplied string.
+ *
+ * Returns true if the string buffer's contents ends with 'str', else false.
+ */
+bool string_buffer_ends_with(string_buffer_t *sb, const char *str);
+
+/**
+ * Returns the string-length of the contents of the string buffer (not counting \0).
+ * Equivalent to calling strlen() on the string returned by string_buffer_to_string(sb).
+ */
+size_t string_buffer_size(string_buffer_t *sb);
+
+/**
+ * Returns the contents of the string buffer in a newly-allocated string, which
+ * it is the caller's responsibility to free once it is no longer needed.
+ */
+char *string_buffer_to_string(string_buffer_t *sb);
+
+/**
+ * Clears the contents of the string buffer, setting its length to zero.
+ */
+void string_buffer_reset(string_buffer_t *sb);
+
+//////////////////////////////////////////////////////
+// String Feeder
+
+/**
+ * Creates a string feeder object which can be used to traverse the supplied
+ * string using the string_feeder_*() functions. A local copy of the string's
+ * contents will be stored so that future changes to 'str' will not be
+ * reflected by the string feeder object.
+ *
+ * It is the caller's responsibility to call string_feeder_destroy() on the
+ * returned object when it is no longer needed.
+ */
+string_feeder_t *string_feeder_create(const char *str);
+
+/**
+ * Frees resources associated with the supplied string feeder object, after
+ * which it will no longer be valid for use.
+ */
+void string_feeder_destroy(string_feeder_t *sf);
+
+/**
+ * Determines whether any characters remain to be retrieved from the string
+ * feeder's string (not including the terminating '\0').
+ *
+ * Returns true if at least one more character can be retrieved with calls to
+ * string_feeder_next(), string_feeder_peek(), string_feeder_peek(), or
+ * string_feeder_consume(), else false.
+ */
+bool string_feeder_has_next(string_feeder_t *sf);
+
+/**
+ * Retrieves the next available character from the supplied string feeder
+ * (which may be the terminating '\0' character) and advances the feeder's
+ * position to the next character in the string.
+ *
+ * Note: Attempts to read past the end of the string will throw an assertion.
+ */
+char string_feeder_next(string_feeder_t *sf);
+
+/**
+ * Retrieves a series of characters from the supplied string feeder. The number
+ * of characters returned will be 'length' or the number of characters
+ * remaining in the string, whichever is shorter. The string feeder's position
+ * will be advanced by the number of characters returned.
+ *
+ * It is the caller's responsibility to free the returned string when it is no
+ * longer needed.
+ *
+ * Note: Calling once the end of the string has already been read will throw an assertion.
+ */
+char *string_feeder_next_length(string_feeder_t *sf, size_t length);
+
+/**
+ * Retrieves the next available character from the supplied string feeder
+ * (which may be the terminating '\0' character), but does not advance
+ * the feeder's position so that subsequent calls to _next() or _peek() will
+ * retrieve the same character.
+ *
+ * Note: Attempts to peek past the end of the string will throw an assertion.
+ */
+char string_feeder_peek(string_feeder_t *sf);
+
+/**
+ * Retrieves a series of characters from the supplied string feeder. The number
+ * of characters returned will be 'length' or the number of characters
+ * remaining in the string, whichever is shorter. The string feeder's position
+ * will not be advanced.
+ *
+ * It is the caller's responsibility to free the returned string when it is no
+ * longer needed.
+ *
+ * Note: Calling once the end of the string has already been read will throw an assertion.
+ */
+char *string_feeder_peek_length(string_feeder_t *sf, size_t length);
+
+/**
+ * Retrieves the line number of the current position in the supplied
+ * string feeder, which will be incremented whenever a newline is consumed.
+ *
+ * Examples:
+ *   prior to reading 1st character:                line = 1, column = 0
+ *   after reading 1st non-newline character:       line = 1, column = 1
+ *   after reading 2nd non-newline character:       line = 1, column = 2
+ *   after reading 1st newline character:           line = 2, column = 0
+ *   after reading 1st character after 1st newline: line = 2, column = 1
+ *   after reading 2nd newline character:           line = 3, column = 0
+ */
+int string_feeder_get_line(string_feeder_t *sf);
+
+/**
+ * Retrieves the column index in the current line for the current position
+ * in the supplied string feeder, which will be incremented with each
+ * non-newline character consumed, and reset to 0 whenever a newline (\n) is
+ * consumed.
+ *
+ * Examples:
+ *   prior to reading 1st character:                line = 1, column = 0
+ *   after reading 1st non-newline character:       line = 1, column = 1
+ *   after reading 2nd non-newline character:       line = 1, column = 2
+ *   after reading 1st newline character:           line = 2, column = 0
+ *   after reading 1st character after 1st newline: line = 2, column = 1
+ *   after reading 2nd newline character:           line = 3, column = 0
+ */
+int string_feeder_get_column(string_feeder_t *sf);
+
+/**
+ * Determines whether the supplied string feeder's remaining contents starts
+ * with the given string.
+ *
+ * Returns true if the beginning of the string feeder's remaining contents matches
+ * the supplied string exactly, else false.
+ */
+bool string_feeder_starts_with(string_feeder_t *sf, const char *str);
+
+/**
+ * Consumes from the string feeder the number of characters contained in the
+ * given string (not including the terminating '\0').
+ *
+ * Throws an assertion if the consumed characters do not exactly match the
+ * contents of the supplied string.
+ */
+void string_feeder_require(string_feeder_t *sf, const char *str);
+
+/*#ifndef strdup
+    static inline char *strdup(const char *s) {
+        int len = strlen(s);
+        char *out = malloc(len+1);
+        memcpy(out, s, len + 1);
+        return out;
+    }
+#endif
+*/
+
+
+// find everything that looks like an env variable and expand it
+// using getenv. Caller should free the result.
+// e.g. "$HOME/abc" ==> "/home/ebolson/abc"
+char *str_expand_envs(const char *in);
+
+#ifdef __cplusplus
+}
+#endif

--- a/common/zhash.c
+++ b/common/zhash.c
@@ -1,0 +1,563 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "zhash.h"
+
+// force a rehash when our capacity is less than this many times the size
+#define ZHASH_FACTOR_CRITICAL 2
+
+// When resizing, how much bigger do we want to be? (should be greater than _CRITICAL)
+#define ZHASH_FACTOR_REALLOC 4
+
+struct zhash
+{
+    size_t keysz, valuesz;
+    int    entrysz; // valid byte (1) + keysz + values
+
+    uint32_t(*hash)(const void *a);
+
+    // returns 1 if equal
+    int(*equals)(const void *a, const void *b);
+
+    int size; // # of items in hash table
+
+    char *entries; // each entry of size entrysz;
+    int  nentries; // how many entries are allocated? Never 0.
+};
+
+zhash_t *zhash_create_capacity(size_t keysz, size_t valuesz,
+                               uint32_t(*hash)(const void *a), int(*equals)(const void *a, const void*b),
+                               int capacity)
+{
+    assert(hash != NULL);
+    assert(equals != NULL);
+
+    // resize...
+    int _nentries = ZHASH_FACTOR_REALLOC * capacity;
+    if (_nentries < 8)
+        _nentries = 8;
+
+    // to a power of 2.
+    int nentries = _nentries;
+    if ((nentries & (nentries - 1)) != 0) {
+        nentries = 8;
+        while (nentries < _nentries)
+            nentries *= 2;
+    }
+
+    zhash_t *zh = (zhash_t*) calloc(1, sizeof(zhash_t));
+    zh->keysz = keysz;
+    zh->valuesz = valuesz;
+    zh->hash = hash;
+    zh->equals = equals;
+    zh->nentries = nentries;
+
+    zh->entrysz = 1 + zh->keysz + zh->valuesz;
+
+    zh->entries = calloc(zh->nentries, zh->entrysz);
+    zh->nentries = nentries;
+
+    return zh;
+}
+
+zhash_t *zhash_create(size_t keysz, size_t valuesz,
+                      uint32_t(*hash)(const void *a), int(*equals)(const void *a, const void *b))
+{
+    return zhash_create_capacity(keysz, valuesz, hash, equals, 8);
+}
+
+void zhash_destroy(zhash_t *zh)
+{
+    if (zh == NULL)
+        return;
+
+    free(zh->entries);
+    free(zh);
+}
+
+int zhash_size(const zhash_t *zh)
+{
+    return zh->size;
+}
+
+void zhash_clear(zhash_t *zh)
+{
+    memset(zh->entries, 0, zh->nentries * zh->entrysz);
+    zh->size = 0;
+}
+
+int zhash_get_volatile(const zhash_t *zh, const void *key, void *out_value)
+{
+    uint32_t code = zh->hash(key);
+    uint32_t entry_idx = code & (zh->nentries - 1);
+
+    while (zh->entries[entry_idx * zh->entrysz]) {
+        void *this_key = &zh->entries[entry_idx * zh->entrysz + 1];
+        if (zh->equals(key, this_key)) {
+            *((void**) out_value) = &zh->entries[entry_idx * zh->entrysz + 1 + zh->keysz];
+            return 1;
+        }
+
+        entry_idx = (entry_idx + 1) & (zh->nentries - 1);
+    }
+
+    return 0;
+}
+
+int zhash_get(const zhash_t *zh, const void *key, void *out_value)
+{
+    void *tmp;
+    if (zhash_get_volatile(zh, key, &tmp)) {
+        memcpy(out_value, tmp, zh->valuesz);
+        return 1;
+    }
+
+    return 0;
+}
+
+int zhash_put(zhash_t *zh, const void *key, const void *value, void *oldkey, void *oldvalue)
+{
+    uint32_t code = zh->hash(key);
+    uint32_t entry_idx = code & (zh->nentries - 1);
+
+    while (zh->entries[entry_idx * zh->entrysz]) {
+        void *this_key = &zh->entries[entry_idx * zh->entrysz + 1];
+        void *this_value = &zh->entries[entry_idx * zh->entrysz + 1 + zh->keysz];
+
+        if (zh->equals(key, this_key)) {
+            // replace
+            if (oldkey)
+                memcpy(oldkey, this_key, zh->keysz);
+            if (oldvalue)
+                memcpy(oldvalue, this_value, zh->valuesz);
+            memcpy(this_key, key, zh->keysz);
+            memcpy(this_value, value, zh->valuesz);
+            zh->entries[entry_idx * zh->entrysz] = 1; // mark valid
+            return 1;
+        }
+
+        entry_idx = (entry_idx + 1) & (zh->nentries - 1);
+    }
+
+    // add the entry
+    zh->entries[entry_idx * zh->entrysz] = 1;
+    memcpy(&zh->entries[entry_idx * zh->entrysz + 1], key, zh->keysz);
+    memcpy(&zh->entries[entry_idx * zh->entrysz + 1 + zh->keysz], value, zh->valuesz);
+    zh->size++;
+
+    if (zh->nentries < ZHASH_FACTOR_CRITICAL * zh->size) {
+        zhash_t *newhash = zhash_create_capacity(zh->keysz, zh->valuesz,
+                                                 zh->hash, zh->equals,
+                                                 zh->size);
+
+        for (int idx = 0; idx < zh->nentries; idx++) {
+
+            if (zh->entries[idx * zh->entrysz]) {
+                void *this_key = &zh->entries[idx * zh->entrysz + 1];
+                void *this_value = &zh->entries[idx * zh->entrysz + 1 + zh->keysz];
+                if (zhash_put(newhash, this_key, this_value, NULL, NULL))
+                    assert(0); // shouldn't already be present.
+            }
+        }
+
+        // play switch-a-roo
+        zhash_t tmp;
+        memcpy(&tmp, zh, sizeof(zhash_t));
+        memcpy(zh, newhash, sizeof(zhash_t));
+        memcpy(newhash, &tmp, sizeof(zhash_t));
+        zhash_destroy(newhash);
+    }
+
+    return 0;
+}
+
+int zhash_remove(zhash_t *zh, const void *key, void *old_key, void *old_value)
+{
+    uint32_t code = zh->hash(key);
+    uint32_t entry_idx = code & (zh->nentries - 1);
+
+    while (zh->entries[entry_idx * zh->entrysz]) {
+        void *this_key = &zh->entries[entry_idx * zh->entrysz + 1];
+        void *this_value = &zh->entries[entry_idx * zh->entrysz + 1 + zh->keysz];
+
+        if (zh->equals(key, this_key)) {
+            if (old_key)
+                memcpy(old_key, this_key, zh->keysz);
+            if (old_value)
+                memcpy(old_value, this_value, zh->valuesz);
+
+            // mark this entry as available
+            zh->entries[entry_idx * zh->entrysz] = 0;
+            zh->size--;
+
+            // reinsert any consecutive entries that follow
+            while (1) {
+                entry_idx = (entry_idx + 1) & (zh->nentries - 1);
+
+                if (zh->entries[entry_idx * zh->entrysz]) {
+                    // completely remove this entry
+                    char *tmp = malloc(sizeof(char)*zh->entrysz);
+                    memcpy(tmp, &zh->entries[entry_idx * zh->entrysz], zh->entrysz);
+                    zh->entries[entry_idx * zh->entrysz] = 0;
+                    zh->size--;
+                    // reinsert it
+                    if (zhash_put(zh, &tmp[1], &tmp[1+zh->keysz], NULL, NULL))
+                        assert(0);
+                    free(tmp);
+                } else {
+                    break;
+                }
+            }
+            return 1;
+        }
+
+        entry_idx = (entry_idx + 1) & (zh->nentries - 1);
+    }
+
+    return 0;
+}
+
+zhash_t *zhash_copy(const zhash_t *zh)
+{
+    zhash_t *newhash = zhash_create_capacity(zh->keysz, zh->valuesz,
+                                             zh->hash, zh->equals,
+                                             zh->size);
+
+    for (int entry_idx = 0; entry_idx < zh->nentries; entry_idx++) {
+        if (zh->entries[entry_idx * zh->entrysz]) {
+            void *this_key = &zh->entries[entry_idx * zh->entrysz + 1];
+            void *this_value = &zh->entries[entry_idx * zh->entrysz + 1 + zh->keysz];
+            if (zhash_put(newhash, this_key, this_value, NULL, NULL))
+                assert(0); // shouldn't already be present.
+        }
+    }
+
+    return newhash;
+}
+
+int zhash_contains(const zhash_t *zh, const void *key)
+{
+    void *tmp;
+    return zhash_get_volatile(zh, key, &tmp);
+}
+
+void zhash_iterator_init(zhash_t *zh, zhash_iterator_t *zit)
+{
+    zit->zh = zh;
+    zit->czh = zh;
+    zit->last_entry = -1;
+}
+
+void zhash_iterator_init_const(const zhash_t *zh, zhash_iterator_t *zit)
+{
+    zit->zh = NULL;
+    zit->czh = zh;
+    zit->last_entry = -1;
+}
+
+int zhash_iterator_next_volatile(zhash_iterator_t *zit, void *outkey, void *outvalue)
+{
+    const zhash_t *zh = zit->czh;
+
+    while (1) {
+        if (zit->last_entry + 1 >= zh->nentries)
+            return 0;
+
+        zit->last_entry++;
+
+        if (zh->entries[zit->last_entry * zh->entrysz]) {
+            void *this_key = &zh->entries[zit->last_entry * zh->entrysz + 1];
+            void *this_value = &zh->entries[zit->last_entry * zh->entrysz + 1 + zh->keysz];
+
+            if (outkey != NULL)
+                *((void**) outkey) = this_key;
+            if (outvalue != NULL)
+                *((void**) outvalue) = this_value;
+
+            return 1;
+        }
+    }
+}
+
+int zhash_iterator_next(zhash_iterator_t *zit, void *outkey, void *outvalue)
+{
+    const zhash_t *zh = zit->czh;
+
+    void *outkeyp, *outvaluep;
+
+    if (!zhash_iterator_next_volatile(zit, &outkeyp, &outvaluep))
+        return 0;
+
+    if (outkey != NULL)
+        memcpy(outkey, outkeyp, zh->keysz);
+    if (outvalue != NULL)
+        memcpy(outvalue, outvaluep, zh->valuesz);
+
+    return 1;
+}
+
+void zhash_iterator_remove(zhash_iterator_t *zit)
+{
+    assert(zit->zh); // can't call _remove on a iterator with const zhash
+    zhash_t *zh = zit->zh;
+
+    zh->entries[zit->last_entry * zh->entrysz] = 0;
+    zh->size--;
+
+    // re-insert following entries
+    int entry_idx = (zit->last_entry + 1) & (zh->nentries - 1);
+    while (zh->entries[entry_idx *zh->entrysz]) {
+        // completely remove this entry
+        char *tmp = malloc(sizeof(char)*zh->entrysz);
+        memcpy(tmp, &zh->entries[entry_idx * zh->entrysz], zh->entrysz);
+        zh->entries[entry_idx * zh->entrysz] = 0;
+        zh->size--;
+
+        // reinsert it
+        if (zhash_put(zh, &tmp[1], &tmp[1+zh->keysz], NULL, NULL))
+            assert(0);
+        free(tmp);
+
+        entry_idx = (entry_idx + 1) & (zh->nentries - 1);
+    }
+
+    zit->last_entry--;
+}
+
+void zhash_map_keys(zhash_t *zh, void (*f)())
+{
+    assert(zh != NULL);
+    if (f == NULL)
+        return;
+
+    zhash_iterator_t itr;
+    zhash_iterator_init(zh, &itr);
+
+    void *key, *value;
+
+    while(zhash_iterator_next_volatile(&itr, &key, &value)) {
+        f(key);
+    }
+}
+
+void zhash_vmap_keys(zhash_t * zh, void (*f)())
+{
+    assert(zh != NULL);
+    if (f == NULL)
+        return;
+
+    zhash_iterator_t itr;
+    zhash_iterator_init(zh, &itr);
+
+    void *key, *value;
+
+    while(zhash_iterator_next_volatile(&itr, &key, &value)) {
+        void *p = *(void**) key;
+        f(p);
+    }
+}
+
+void zhash_map_values(zhash_t * zh, void (*f)())
+{
+    assert(zh != NULL);
+    if (f == NULL)
+        return;
+
+    zhash_iterator_t itr;
+    zhash_iterator_init(zh, &itr);
+
+    void *key, *value;
+    while(zhash_iterator_next_volatile(&itr, &key, &value)) {
+        f(value);
+    }
+}
+
+void zhash_vmap_values(zhash_t * zh, void (*f)())
+{
+    assert(zh != NULL);
+    if (f == NULL)
+        return;
+
+    zhash_iterator_t itr;
+    zhash_iterator_init(zh, &itr);
+
+    void *key, *value;
+    while(zhash_iterator_next_volatile(&itr, &key, &value)) {
+        void *p = *(void**) value;
+        f(p);
+    }
+}
+
+zarray_t *zhash_keys(const zhash_t *zh)
+{
+    assert(zh != NULL);
+
+    zarray_t *za = zarray_create(zh->keysz);
+
+    zhash_iterator_t itr;
+    zhash_iterator_init_const(zh, &itr);
+
+    void *key, *value;
+    while(zhash_iterator_next_volatile(&itr, &key, &value)) {
+        zarray_add(za, key);
+    }
+
+    return za;
+}
+
+zarray_t *zhash_values(const zhash_t *zh)
+{
+    assert(zh != NULL);
+
+    zarray_t *za = zarray_create(zh->valuesz);
+
+    zhash_iterator_t itr;
+    zhash_iterator_init_const(zh, &itr);
+
+    void *key, *value;
+    while(zhash_iterator_next_volatile(&itr, &key, &value)) {
+        zarray_add(za, value);
+    }
+
+    return za;
+}
+
+
+uint32_t zhash_uint32_hash(const void *_a)
+{
+    assert(_a != NULL);
+
+    uint32_t a = *((uint32_t*) _a);
+    return a;
+}
+
+int zhash_uint32_equals(const void *_a, const void *_b)
+{
+    assert(_a != NULL);
+    assert(_b != NULL);
+
+    uint32_t a = *((uint32_t*) _a);
+    uint32_t b = *((uint32_t*) _b);
+
+    return a==b;
+}
+
+uint32_t zhash_uint64_hash(const void *_a)
+{
+    assert(_a != NULL);
+
+    uint64_t a = *((uint64_t*) _a);
+    return (uint32_t) (a ^ (a >> 32));
+}
+
+int zhash_uint64_equals(const void *_a, const void *_b)
+{
+    assert(_a != NULL);
+    assert(_b != NULL);
+
+    uint64_t a = *((uint64_t*) _a);
+    uint64_t b = *((uint64_t*) _b);
+
+    return a==b;
+}
+
+
+union uintpointer
+{
+    const void *p;
+    uint32_t i;
+};
+
+uint32_t zhash_ptr_hash(const void *a)
+{
+    assert(a != NULL);
+
+    union uintpointer ip;
+    ip.p = * (void**)a;
+
+    // compute a hash from the lower 32 bits of the pointer (on LE systems)
+    uint32_t hash = ip.i;
+    hash ^= (hash >> 7);
+
+    return hash;
+}
+
+
+int zhash_ptr_equals(const void *a, const void *b)
+{
+    assert(a != NULL);
+    assert(b != NULL);
+
+    const void * ptra = * (void**)a;
+    const void * ptrb = * (void**)b;
+    return  ptra == ptrb;
+}
+
+
+int zhash_str_equals(const void *_a, const void *_b)
+{
+    assert(_a != NULL);
+    assert(_b != NULL);
+
+    char *a = * (char**)_a;
+    char *b = * (char**)_b;
+
+    return !strcmp(a, b);
+}
+
+uint32_t zhash_str_hash(const void *_a)
+{
+    assert(_a != NULL);
+
+    char *a = * (char**)_a;
+
+    uint32_t hash = 0;
+    while (*a != 0) {
+        // optimization of hash x FNV_prime
+        hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+        hash ^= *a;
+        a++;
+    }
+
+    return hash;
+}
+
+
+void zhash_debug(zhash_t *zh)
+{
+    for (int entry_idx = 0; entry_idx < zh->nentries; entry_idx++) {
+        char *k, *v;
+        memcpy(&k, &zh->entries[entry_idx * zh->entrysz + 1], sizeof(char*));
+        memcpy(&v, &zh->entries[entry_idx * zh->entrysz + 1 + zh->keysz], sizeof(char*));
+        printf("%d: %d, %s => %s\n", entry_idx, zh->entries[entry_idx * zh->entrysz], k, v);
+    }
+}

--- a/common/zhash.h
+++ b/common/zhash.h
@@ -1,0 +1,432 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "zarray.h"
+
+
+/**
+ * A hash table for structs and primitive types that stores entries by value.
+ *   - The size of the key/values must be known at instantiation time, and remain fixed.
+ *     e.g. for pointers: zhash_create(sizeof(void*), sizeof(void*)....)
+ *          for structs: zhash_create(sizeof(struct key_struct), sizeof(struct value_struct)...)
+ *          for bytes: zhash_create(sizeof(uint8_t), sizeof(uint8_t)...)
+ *   - Entries are copied by value. This means you must always pass a reference to the start
+ *     of 'key_size' and 'value_size' bytes, which you have already malloc'd or stack allocated
+ *   - This data structure can be used to store types of any size, from bytes & doubles to
+ *     user defined structs
+ *     Note: if zhash stores pointers, user must be careful to manually manage the lifetime
+ *     of the memory they point to.
+ *
+ */
+
+typedef struct zhash zhash_t;
+
+// The contents of the iterator should be considered private. However,
+// since our usage model prefers stack-based allocation of iterators,
+// we must publicly declare them.
+struct zhash_iterator
+{
+    zhash_t *zh;
+    const zhash_t *czh;
+    int last_entry; // points to the last entry returned by _next
+};
+
+typedef struct zhash_iterator zhash_iterator_t;
+
+/**
+ * Create, initializes, and returns an empty hash table structure. It is the
+ * caller's responsibility to call zhash_destroy() on the returned array when it
+ * is no longer needed.
+ *
+ * The size of values used in the hash and equals function must match 'keysz'.
+ * I.e. if keysz = sizeof(uint64_t), then hash() and equals() should accept
+ * parameters as *uint64_t.
+ */
+zhash_t *zhash_create(size_t keysz, size_t valuesz,
+                      uint32_t(*hash)(const void *a),
+                      int(*equals)(const void *a, const void *b));
+
+/**
+ * Frees all resources associated with the hash table structure which was
+ * created by zhash_create(). After calling, 'zh' will no longer be valid for storage.
+ *
+ * If 'zh' contains pointer data, it is the caller's responsibility to manage
+ * the resources pointed to by those pointers.
+ */
+void zhash_destroy(zhash_t *zh);
+
+/**
+ * Creates and returns a new identical copy of the zhash (i.e. a "shallow" copy).
+ * If you're storing pointers, be sure not to double free their pointees!
+ * It is the caller's responsibility to call zhash_destroy() on the returned array
+ * when it is no longer needed (in addition to the zhash_destroy() call for the
+ * original zhash).
+ */
+zhash_t * zhash_copy(const zhash_t* other);
+
+/**
+ * Determines whether the supplied key value exists as an entry in the zhash
+ * table. If zhash stores pointer types as keys, this function can differentiate
+ * between a non-existent key and a key mapped to NULL.
+ * Returns 1 if the supplied key exists in the zhash table, else 0.
+ */
+int zhash_contains(const zhash_t *zh, const void *key);
+
+/**
+ * Retrieves the value for the given key, if it exists, by copying its contents
+ * into the space pointed to by 'out_value', which must already be allocated.
+ * Returns 1 if the supplied key exists in the table, else 0, in which case
+ * the contents of 'out_value' will be unchanged.
+ */
+int zhash_get(const zhash_t *zh, const void *key, void *out_value);
+
+/**
+ * Similar to zhash_get(), but more dangerous. Provides a pointer to the zhash's
+ * internal storage.  This can be used to make simple modifications to
+ * the underlying data while avoiding the memcpys associated with
+ * zhash_get and zhash_put. However, some zhash operations (that
+ * resize the underlying storage, in particular) render this pointer
+ * invalid. For maximum safety, call no other zhash functions for the
+ * period during which you intend to use the pointer.
+ * 'out_p' should be a pointer to the pointer which will be set to the internal
+ * data address.
+ */
+int zhash_get_volatile(const zhash_t *zh, const void *key, void *out_p);
+
+/**
+ * Adds a key/value pair to the hash table, if the supplied key does not already
+ * exist in the table, or overwrites the value for the supplied key if it does
+ * already exist. In the latter case, the previous contents of the key and value
+ * will be copied into the spaces pointed to by 'oldkey' and 'oldvalue', respectively,
+ * if they are not NULL.
+ *
+ * The key/value is added to / updated in the hash table by copying 'keysz' bytes
+ * from the data pointed to by 'key' and 'valuesz' bytes from the data pointed
+ * to by 'value'. It is up to the caller to manage the memory allocation of the
+ * passed-in values, zhash will store and manage a copy.
+ *
+ * NOTE: If the key is a pointer type (such as a string), the contents of the
+ * data that it points to must not be modified after the call to zhash_put(),
+ * or future zhash calls will not successfully locate the key (using either its
+ * previous or new value).
+ *
+ * NOTE: When using array data as a key (such as a string), the array should not
+ * be passed directly or it will cause a segmentation fault when it is dereferenced.
+ * Instead, pass a pointer which points to the array location, i.e.:
+ *   char key[strlen];
+ *   char *keyptr = key;
+ *   zhash_put(zh, &keyptr, ...)
+ *
+ * Example:
+ *   char * key = ...;
+ *   zarray_t * val = ...;
+ *   char * old_key = NULL;
+ *   zarray_t * old_val = NULL;
+ *   if (zhash_put(zh, &key, &val, &old_key, &old_value))
+ *       // manage resources for old_key and old_value
+ *
+ * Returns 1 if the supplied key previously existed in the table, else 0, in
+ * which case the data pointed to by 'oldkey' and 'oldvalue' will be set to zero
+ * if they are not NULL.
+ */
+int zhash_put(zhash_t *zh, const void *key, const void *value, void *oldkey, void *oldvalue);
+
+/**
+ * Removes from the zhash table the key/value pair for the supplied key, if
+ * it exists. If it does, the contents of the key and value will be copied into
+ * the spaces pointed to by 'oldkey' and 'oldvalue', respectively, if they are
+ * not NULL. If the key does not exist, the data pointed to by 'oldkey' and
+ * 'oldvalue' will be set to zero if they are not NULL.
+ *
+ * Returns 1 if the key existed and was removed, else 0, indicating that the
+ * table contents were not changed.
+ */
+int zhash_remove(zhash_t *zh, const void *key, void *oldkey, void *oldvalue);
+
+/**
+ * Removes all entries in the has table to create the equivalent of starting from
+ * a zhash_create(), using the same size parameters. If any elements need to be
+ * freed manually, this will need to occur before calling clear.
+ */
+void zhash_clear(zhash_t *zh);
+
+/**
+ * Retrieves the current number of key/value pairs currently contained in the
+ * zhash table, or 0 if the table is empty.
+ */
+int zhash_size(const zhash_t *zh);
+
+/**
+ * Initializes an iterator which can be used to traverse the key/value pairs of
+ * the supplied zhash table via successive calls to zhash_iterator_next() or
+ * zhash_iterator_next_volatile(). The iterator can also be used to remove elements
+ * from the zhash with zhash_iterator_remove().
+ *
+ * Any modifications to the zhash table structure will invalidate the
+ * iterator, with the exception of zhash_iterator_remove().
+ */
+void zhash_iterator_init(zhash_t *zh, zhash_iterator_t *zit);
+
+/**
+ * Initializes an iterator which can be used to traverse the key/value pairs of
+ * the supplied zhash table via successive calls to zhash_iterator_next() or
+ * zhash_iterator_next_volatile().
+ *
+ * An iterator initialized with this function cannot be used with
+ * zhash_iterator_remove(). For that you must use zhash_iterator_init().
+ *
+ * Any modifications to the zhash table structure will invalidate the
+ * iterator.
+ */
+void zhash_iterator_init_const(const zhash_t *zh, zhash_iterator_t *zit);
+
+/**
+ * Retrieves the next key/value pair from a zhash table via the (previously-
+ * initialized) iterator. Copies the key and value data into the space
+ * pointed to by outkey and outvalue, respectively, if they are not NULL.
+ *
+ * Returns 1 if the call retrieved the next available key/value pair, else 0
+ * indicating that no entries remain, in which case the contents of outkey and
+ * outvalue will remain unchanged.
+ */
+int zhash_iterator_next(zhash_iterator_t *zit, void *outkey, void *outvalue);
+
+/**
+ * Similar to zhash_iterator_next() except that it retrieves a pointer to zhash's
+ * internal storage.  This can be used to avoid the memcpys associated with
+ * zhash_iterator_next(). Call no other zhash functions for the
+ * period during which you intend to use the pointer.
+ * 'outkey' and 'outvalue' should be pointers to the pointers which will be set
+ * to the internal data addresses.
+ *
+ * Example:
+ *   key_t *outkey;
+ *   value_t *outvalue;
+ *   if (zhash_iterator_next_volatile(&zit, &outkey, &outvalue))
+ *       // access internal key and value storage via outkey and outvalue
+ *
+ * Returns 1 if the call retrieved the next available key/value pair, else 0
+ * indicating that no entries remain, in which case the pointers outkey and
+ * outvalue will remain unchanged.
+ */
+int zhash_iterator_next_volatile(zhash_iterator_t *zit, void *outkey, void *outvalue);
+
+/**
+ * Removes from the zhash table the key/value pair most recently returned via
+ * a call to zhash_iterator_next() or zhash_iterator_next_volatile() for the
+ * supplied iterator.
+ *
+ * Requires that the iterator was initialized with zhash_iterator_init(),
+ * not zhash_iterator_init_const().
+ */
+void zhash_iterator_remove(zhash_iterator_t *zit);
+
+/**
+ * Calls the supplied function with a pointer to every key in the hash table in
+ * turn. The function will be passed a pointer to the table's internal storage
+ * for the key, which the caller should not modify, as the hash table will not be
+ * re-indexed. The function may be NULL, in which case no action is taken.
+ */
+void zhash_map_keys(zhash_t *zh, void (*f)());
+
+/**
+ * Calls the supplied function with a pointer to every value in the hash table in
+ * turn. The function will be passed a pointer to the table's internal storage
+ * for the value, which the caller may safely modify. The function may be NULL,
+ * in which case no action is taken.
+ */
+void zhash_map_values(zhash_t *zh, void (*f)());
+
+/**
+ * Calls the supplied function with a copy of every key in the hash table in
+ * turn. While zhash_map_keys() passes a pointer to internal storage, this function
+ * passes a copy of the actual storage. If the zhash stores pointers to data,
+ * functions like free() can be used directly with zhash_vmap_keys().
+ * The function may be NULL, in which case no action is taken.
+ *
+ * NOTE: zhash_vmap_keys() can only be used with pointer-data keys.
+ * Use with non-pointer keys (i.e. integer, double, etc.) will likely cause a
+ * segmentation fault.
+ */
+void zhash_vmap_keys(zhash_t *vh, void (*f)());
+
+/**
+ * Calls the supplied function with a copy of every value in the hash table in
+ * turn. While zhash_map_values() passes a pointer to internal storage, this function
+ * passes a copy of the actual storage. If the zhash stores pointers to data,
+ * functions like free() can be used directly with zhash_vmap_values().
+ * The function may be NULL, in which case no action is taken.
+ *
+ * NOTE: zhash_vmap_values() can only be used with pointer-data values.
+ * Use with non-pointer values (i.e. integer, double, etc.) will likely cause a
+ * segmentation fault.
+ */
+void zhash_vmap_values(zhash_t *vh, void (*f)());
+
+/**
+ * Returns an array which contains copies of all of the hash table's keys, in no
+ * particular order. It is the caller's responsibility to call zarray_destroy()
+ * on the returned structure when it is no longer needed.
+ */
+zarray_t *zhash_keys(const zhash_t *zh);
+
+/**
+ * Returns an array which contains copies of all of the hash table's values, in no
+ * particular order. It is the caller's responsibility to call zarray_destroy()
+ * on the returned structure when it is no longer needed.
+ */
+zarray_t *zhash_values(const zhash_t *zh);
+
+/**
+ * Defines a hash function which will calculate a zhash value for uint32_t input
+ * data. Can be used with zhash_create() for a key size of sizeof(uint32_t).
+ */
+uint32_t zhash_uint32_hash(const void *a);
+
+/**
+ * Defines a function to compare zhash values for uint32_t input data.
+ * Can be used with zhash_create() for a key size of sizeof(uint32_t).
+ */
+int zhash_uint32_equals(const void *a, const void *b);
+
+/**
+ * Defines a hash function which will calculate a zhash value for uint64_t input
+ * data. Can be used with zhash_create() for a key size of sizeof(uint64_t).
+ */
+uint32_t zhash_uint64_hash(const void *a);
+
+/**
+ * Defines a function to compare zhash values for uint64_t input data.
+ * Can be used with zhash_create() for a key size of sizeof(uint64_t).
+ */
+int zhash_uint64_equals(const void *a, const void *b);
+
+/////////////////////////////////////////////////////
+// functions for keys that can be compared via their pointers.
+/**
+ * Defines a hash function which will calculate a zhash value for pointer input
+ * data. Can be used with zhash_create() for a key size of sizeof(void*). Will
+ * use only the pointer value itself for computing the hash value.
+ */
+uint32_t zhash_ptr_hash(const void *a);
+
+/**
+ * Defines a function to compare zhash values for pointer input data.
+ * Can be used with zhash_create() for a key size of sizeof(void*).
+ */
+int zhash_ptr_equals(const void *a, const void *b);
+
+/////////////////////////////////////////////////////
+// Functions for string-typed keys
+/**
+ * Defines a hash function which will calculate a zhash value for string input
+ * data. Can be used with zhash_create() for a key size of sizeof(char*). Will
+ * use the contents of the string in computing the hash value.
+ */
+uint32_t zhash_str_hash(const void *a);
+
+/**
+ * Defines a function to compare zhash values for string input data.
+ * Can be used with zhash_create() for a key size of sizeof(char*).
+ */
+int zhash_str_equals(const void *a, const void *b);
+
+void zhash_debug(zhash_t *zh);
+
+    static inline zhash_t *zhash_str_str_create(void)
+    {
+        return zhash_create(sizeof(char*), sizeof(char*),
+                            zhash_str_hash, zhash_str_equals);
+    }
+
+
+
+// for zhashes that map strings to strings, this is a convenience
+// function that allows easier retrieval of values. NULL is returned
+// if the key is not found.
+static inline char *zhash_str_str_get(zhash_t *zh, const char *key)
+{
+    char *value;
+    if (zhash_get(zh, &key, &value))
+        return value;
+    return NULL;
+}
+
+    static inline void zhash_str_str_put(zhash_t *zh, char *key, char *value)
+    {
+        char *oldkey, *oldval;
+        if (zhash_put(zh, &key, &value, &oldkey, &oldval)) {
+            free(oldkey);
+            free(oldval);
+        }
+    }
+
+    static inline void zhash_str_str_destroy(zhash_t *zh)
+    {
+        zhash_iterator_t zit;
+        zhash_iterator_init(zh, &zit);
+
+        char *key, *value;
+        while (zhash_iterator_next(&zit, &key, &value)) {
+            free(key);
+            free(value);
+        }
+
+        zhash_destroy(zh);
+    }
+
+
+static inline uint32_t zhash_int_hash(const void *_a)
+{
+    assert(_a != NULL);
+
+    uint32_t a = *((int*) _a);
+    return a;
+}
+
+static inline int zhash_int_equals(const void *_a, const void *_b)
+{
+    assert(_a != NULL);
+    assert(_b != NULL);
+
+    int a = *((int*) _a);
+    int b = *((int*) _b);
+
+    return a==b;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/example/apriltag_demo.c
+++ b/example/apriltag_demo.c
@@ -42,6 +42,7 @@ either expressed or implied, of the Regents of The University of Michigan.
 #endif
 
 #include "apriltag.h"
+#include "apriltag_pose.h"
 #include "tag36h11.h"
 #include "tag25h9.h"
 #include "tag16h5.h"
@@ -218,6 +219,27 @@ int main(int argc, char *argv[])
 
                 hamm_hist[det->hamming]++;
                 total_hamm_hist[det->hamming]++;
+
+                apriltag_detection_info_t info = { det, 0.15, 1000, 1000, 1280/2, 720/2 };
+                double err1 = HUGE_VAL; //Should get overwritten if pose estimation is happening
+                double err2 = HUGE_VAL;
+                apriltag_pose_t pose1 = { 0 };
+                apriltag_pose_t pose2 = { 0 };
+                int nIters = 200;
+                estimate_tag_pose_orthogonal_iteration(&info, &err1, &pose1, &err2, &pose2, nIters, 1e-7);
+
+                printf("Primary translation %f %f %f\nerror: %f\n", 
+                    pose1.t->data[0],
+                    pose1.t->data[1],
+                    pose1.t->data[2],
+                    err1
+                );
+                printf("Alt translation %f %f %f\nerror: %f\n", 
+                    pose2.t->data[0],
+                    pose2.t->data[1],
+                    pose2.t->data[2],
+                    err2
+                );
             }
 
             apriltag_detections_destroy(detections);


### PR DESCRIPTION
The current approach wastes iterations doing no work. Exiting early can give lower latencies and higher FPS.

I don't have hardware to find a good tolerance. Ideally, it won't have to be another tunable for the user to worry about.