### PR TITLE
Fix GCC 14 calloc() warning

### DIFF
--- a/common/zmaxheap.c
+++ b/common/zmaxheap.c
@@ -362,7 +362,7 @@ void zmaxheap_test(void)
 {
     int cap = 10000;
     int sz = 0;
-    int32_t *vals = calloc(sizeof(int32_t), cap);
+    int32_t *vals = calloc(cap, sizeof(int32_t));
 
     zmaxheap_t *heap = zmaxheap_create(sizeof(int32_t));
 


### PR DESCRIPTION
```
/home/tav/frc/wpilib/allwpilib/build-cmake-release/_deps/apriltaglib-src/common/zmaxheap.c: In function ‘zmaxheap_test’:
/home/tav/frc/wpilib/allwpilib/build-cmake-release/_deps/apriltaglib-src/common/zmaxheap.c:365:35: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  365 |     int32_t *vals = calloc(sizeof(int32_t), cap);
      |                                   ^~~~~~~
/home/tav/frc/wpilib/allwpilib/build-cmake-release/_deps/apriltaglib-src/common/zmaxheap.c:365:35: note: earlier argument should specify number of elements, later size of each element
```